### PR TITLE
[UI] Preserve EPUB heading breaks in reading position preview

### DIFF
--- a/src/services/reading_position_preview.py
+++ b/src/services/reading_position_preview.py
@@ -14,6 +14,8 @@ import re
 from dataclasses import dataclass
 from typing import Iterable, Optional
 
+from bs4 import BeautifulSoup
+
 logger = logging.getLogger(__name__)
 
 _AUDIO_CLIENTS = {"abs", "bookloreaudio", "bookorbitaudio"}
@@ -159,23 +161,135 @@ def _resolve_precise_or_mapped_position(
     return None, failures
 
 
-def _bounded_excerpt(full_text: str, index: int, context: int) -> tuple[str, str]:
+def _normalized_text(value) -> str:
+    return re.sub(r"\s+", " ", str(value or "")).strip()
+
+
+def _heading_groups(full_text: str, spine_map, marker_index: int) -> list[tuple[int, int]]:
+    """Return unambiguous heading ranges that can safely become line breaks.
+
+    The canonical ebook text deliberately flattens markup.  Preserve only h1-h6
+    boundaries whose raw spine XHTML flattens to the exact canonical slice and
+    whose heading text occurs exactly once in that slice.  Anything ambiguous is
+    left untouched rather than guessing at document structure.
+    """
+    groups: list[tuple[int, int]] = []
+
+    for spine in spine_map or []:
+        if not isinstance(spine, dict):
+            continue
+        content = spine.get("content")
+        try:
+            start = int(spine.get("start"))
+            end = int(spine.get("end"))
+        except (TypeError, ValueError):
+            continue
+        if not content or start < 0 or end <= start or end > len(full_text):
+            continue
+
+        try:
+            soup = BeautifulSoup(content, "html.parser")
+        except Exception:
+            continue
+
+        spine_text = _normalized_text(soup.get_text(separator=" ", strip=True))
+        if not spine_text or full_text[start:end] != spine_text:
+            continue
+
+        spans: list[tuple[int, int]] = []
+        for heading in soup.find_all(re.compile(r"^h[1-6]$", re.IGNORECASE)):
+            heading_text = _normalized_text(heading.get_text(separator=" ", strip=True))
+            if not heading_text:
+                continue
+
+            matches = [match.start() for match in re.finditer(re.escape(heading_text), spine_text)]
+            if len(matches) != 1:
+                continue
+
+            heading_start = start + matches[0]
+            spans.append((heading_start, heading_start + len(heading_text)))
+
+        if not spans:
+            continue
+
+        spans.sort()
+        group_start, group_end = spans[0]
+        for heading_start, heading_end in spans[1:]:
+            between = full_text[group_end:heading_start]
+            if not between.strip():
+                group_end = heading_end
+                continue
+            if not (group_start <= marker_index <= group_end):
+                groups.append((group_start, group_end))
+            group_start, group_end = heading_start, heading_end
+
+        if not (group_start <= marker_index <= group_end):
+            groups.append((group_start, group_end))
+
+    return groups
+
+
+def _format_excerpt_segment(
+    text: str,
+    *,
+    segment_start: int,
+    heading_groups: Iterable[tuple[int, int]],
+) -> str:
+    segment_end = segment_start + len(text)
+    ranges = [
+        (start - segment_start, end - segment_start)
+        for start, end in heading_groups
+        if segment_start <= start < end <= segment_end
+    ]
+    if not ranges:
+        return re.sub(r"\s+", " ", text)
+
+    parts = []
+    cursor = 0
+    for start, end in sorted(ranges):
+        if start < cursor:
+            continue
+        parts.append(text[cursor:start])
+        parts.append("\n")
+        parts.append(text[start:end])
+        parts.append("\n")
+        cursor = end
+    parts.append(text[cursor:])
+
+    formatted = "".join(parts)
+    formatted = re.sub(r"[^\S\n]+", " ", formatted)
+    formatted = re.sub(r" *\n+ *", "\n", formatted)
+    return formatted
+
+
+def _bounded_excerpt(
+    full_text: str,
+    index: int,
+    context: int,
+    heading_groups: Iterable[tuple[int, int]] = (),
+) -> tuple[str, str]:
     if not full_text:
         return "", ""
     index = max(0, min(int(index), len(full_text)))
     context = max(80, min(int(context), 300))
 
-    before = full_text[max(0, index - context):index]
-    after = full_text[index:min(len(full_text), index + context)]
+    before_start = max(0, index - context)
+    after_end = min(len(full_text), index + context)
+    before = _format_excerpt_segment(
+        full_text[before_start:index],
+        segment_start=before_start,
+        heading_groups=heading_groups,
+    )
+    after = _format_excerpt_segment(
+        full_text[index:after_end],
+        segment_start=index,
+        heading_groups=heading_groups,
+    )
 
-    # The canonical parser already normalizes chapter text substantially, but
-    # collapse remaining line breaks/tabs for a compact dashboard excerpt.  Only
-    # the OUTER edges are trimmed: stripping the marker-facing edges deletes the
-    # space the position sits on, so a boundary renders as "several|notches" and
-    # reads as though the marker landed mid-word.
-    before = re.sub(r"\s+", " ", before).lstrip()
-    after = re.sub(r"\s+", " ", after).rstrip()
-    return before, after
+    # Only the OUTER edges are trimmed: stripping the marker-facing edges deletes
+    # the space the position sits on, so a boundary renders as
+    # "several|notches" and reads as though the marker landed mid-word.
+    return before.lstrip(), after.rstrip()
 
 
 def unavailable_preview(message: str, *, source: str = "BookBridge", percentage=None) -> dict:
@@ -226,7 +340,7 @@ def build_reading_position_preview(
 
     try:
         book_path = ebook_parser.resolve_book_path(filename)
-        full_text, _spine_map = ebook_parser.extract_text_and_map(book_path)
+        full_text, spine_map = ebook_parser.extract_text_and_map(book_path)
     except Exception:
         logger.warning(
             "Reading position preview: could not read ebook text for %s",
@@ -234,6 +348,7 @@ def build_reading_position_preview(
             exc_info=True,
         )
         full_text = ""
+        spine_map = []
 
     if not full_text:
         return unavailable_preview(
@@ -270,7 +385,8 @@ def build_reading_position_preview(
         return unavailable_preview(message, source=source, percentage=percentage)
 
     index = max(0, min(int(resolved.index), len(full_text)))
-    before, after = _bounded_excerpt(full_text, index, context_chars)
+    heading_groups = _heading_groups(full_text, spine_map, index)
+    before, after = _bounded_excerpt(full_text, index, context_chars, heading_groups)
     if not before and not after:
         return unavailable_preview(
             "The saved position resolved, but no surrounding ebook text is available.",

--- a/static/css/reading-position-preview.css
+++ b/static/css/reading-position-preview.css
@@ -70,6 +70,7 @@
     font-size: 11px;
     line-height: 1.55;
     overflow-wrap: anywhere;
+    white-space: pre-line;
 }
 
 .position-preview-marker {

--- a/tests/test_reading_position_preview.py
+++ b/tests/test_reading_position_preview.py
@@ -4,8 +4,9 @@ from src.services.reading_position_preview import build_reading_position_preview
 
 
 class FakeParser:
-    def __init__(self, text="abcdefghijklmnopqrstuvwxyz " * 30):
+    def __init__(self, text="abcdefghijklmnopqrstuvwxyz " * 30, spine_map=None):
         self.text = text
+        self.spine_map = spine_map or [{"start": 0, "end": len(self.text)}]
         self.xpath_result = None
         self.cfi_result = None
         self.xpath_calls = []
@@ -17,7 +18,7 @@ class FakeParser:
         return filename
 
     def extract_text_and_map(self, _path):
-        return self.text, [{"start": 0, "end": len(self.text)}]
+        return self.text, self.spine_map
 
     def resolve_xpath_to_index(self, filename, xpath):
         self.xpath_calls.append((filename, xpath))
@@ -59,6 +60,13 @@ def _state(client="kosync", percentage=0.25, **kwargs):
     }
     values.update(kwargs)
     return SimpleNamespace(**values)
+
+
+def _heading_parser(html, text):
+    return FakeParser(
+        text=text,
+        spine_map=[{"start": 0, "end": len(text), "content": html}],
+    )
 
 
 def test_xpath_is_preferred_and_marker_context_is_bounded():
@@ -192,3 +200,102 @@ def test_without_session_leader_newest_state_is_used_as_display_fallback():
     assert result["source"] == "BookOrbit"
     assert result["percentage"] == 70.0
     assert result["status"] == "approximate"
+
+
+def test_real_epub_headings_become_compact_paragraph_boundaries():
+    text = "Before warning. 6 ZENITH / NADIR 6.1 AUFBRUCH Portia sees art."
+    html = (
+        "<html><body><p>Before warning.</p>"
+        "<h1>6 ZENITH / NADIR</h1><h2>6.1 AUFBRUCH</h2>"
+        "<p>Portia sees art.</p></body></html>"
+    )
+    parser = _heading_parser(html, text)
+    parser.xpath_result = text.index("warning") + 3
+
+    result = build_reading_position_preview(
+        book=_book(),
+        states=[_state(xpath="/body/p[1]/text().0")],
+        last_leader="kosync",
+        ebook_parser=parser,
+        context_chars=300,
+    )
+
+    assert "\n6 ZENITH / NADIR 6.1 AUFBRUCH\n" in result["after"]
+    assert "6 ZENITH / NADIR\n6.1 AUFBRUCH" not in result["after"]
+
+
+def test_duplicate_heading_text_is_left_in_plain_flow_when_mapping_is_ambiguous():
+    text = "Chapter One Chapter One appears again in prose."
+    html = (
+        "<html><body><h1>Chapter One</h1>"
+        "<p>Chapter One appears again in prose.</p></body></html>"
+    )
+    parser = _heading_parser(html, text)
+    parser.xpath_result = text.index("appears")
+
+    result = build_reading_position_preview(
+        book=_book(),
+        states=[_state(xpath="/body/p[1]/text().0")],
+        last_leader="kosync",
+        ebook_parser=parser,
+        context_chars=300,
+    )
+
+    assert "\n" not in result["before"]
+    assert "\n" not in result["after"]
+
+
+def test_all_caps_normal_paragraph_is_not_guessed_as_a_heading():
+    text = "Before. THIS IS EMPHASIS NOT A HEADING. After."
+    html = (
+        "<html><body><p>Before.</p>"
+        "<p>THIS IS EMPHASIS NOT A HEADING.</p><p>After.</p></body></html>"
+    )
+    parser = _heading_parser(html, text)
+    parser.xpath_result = text.index("After")
+
+    result = build_reading_position_preview(
+        book=_book(),
+        states=[_state(xpath="/body/p[3]/text().0")],
+        last_leader="kosync",
+        ebook_parser=parser,
+        context_chars=300,
+    )
+
+    assert "\n" not in result["before"]
+    assert "\n" not in result["after"]
+
+
+def test_heading_containing_marker_is_left_in_plain_flow():
+    text = "Before. CHAPTER TITLE After."
+    html = "<html><body><p>Before.</p><h1>CHAPTER TITLE</h1><p>After.</p></body></html>"
+    parser = _heading_parser(html, text)
+    parser.xpath_result = text.index("TITLE") + 2
+
+    result = build_reading_position_preview(
+        book=_book(),
+        states=[_state(xpath="/body/h1/text().0")],
+        last_leader="kosync",
+        ebook_parser=parser,
+        context_chars=300,
+    )
+
+    assert "\n" not in result["before"]
+    assert "\n" not in result["after"]
+
+
+def test_missing_spine_markup_keeps_existing_plain_excerpt_behavior():
+    text = "Before. CHAPTER TITLE After."
+    parser = FakeParser(text=text)
+    parser.xpath_result = text.index("After")
+
+    result = build_reading_position_preview(
+        book=_book(),
+        states=[_state(xpath="/body/p[1]/text().0")],
+        last_leader="kosync",
+        ebook_parser=parser,
+        context_chars=300,
+    )
+
+    assert result["before"] == "Before. CHAPTER TITLE "
+    assert result["after"] == "After."

--- a/tests/test_reading_position_preview_ui.py
+++ b/tests/test_reading_position_preview_ui.py
@@ -45,4 +45,5 @@ def test_preview_css_uses_existing_bookbridge_tokens_and_has_mobile_layout():
     assert 'var(--border)' in css
     assert 'var(--accent)' in css
     assert ':focus-visible' in css
+    assert 'white-space: pre-line' in css
     assert '@media (max-width: 480px)' in css


### PR DESCRIPTION
## Summary

Keeps the on-demand reading-position preview compact while preserving trustworthy EPUB heading structure as simple paragraph boundaries.

The current preview intentionally flattens ebook text, which can make chapter/section headings read like part of the surrounding sentence. This change restores only boundaries that can be mapped safely from real EPUB `<h1>`–`<h6>` elements.

## Behavior

- real EPUB headings become a single compact paragraph break before/after the heading group
- consecutive headings stay together instead of creating stacked visual blocks
- no bold text, badges, colors, chapter boxes, or other new visual hierarchy
- the existing position marker remains the only visual indication of the current reading position
- ambiguous duplicate heading text is left unchanged
- all-caps normal prose is never guessed to be a heading
- a heading containing the current marker is left unchanged
- missing or mismatched spine markup falls back to the existing flat excerpt

## Scope

Intentionally small:

- no payload-schema changes
- no JavaScript changes
- no sync/leader-selection changes
- no database migration
- no new dependency (`BeautifulSoup` is already used by the ebook parser)
- one CSS addition: `white-space: pre-line`

The implementation also preserves the follow-up hardening from #397: source selection, confidence-first locator resolution, bounded on-demand text, text-only DOM rendering, and no locator/path exposure are unchanged.

## Tests

Adds regression coverage for:

- real consecutive EPUB headings
- ambiguous duplicate heading text
- all-caps normal paragraphs
- marker inside a heading
- missing spine markup / legacy fallback
- CSS newline rendering

The branch is based directly on current `dev` (`34f83802fa1ce5e8ae58a143e92baeefee749c9b`) and is one commit ahead with no unrelated changes.

Because the repository's Python workflow runs for PRs targeting `main` while contribution PRs target `dev`, the same feature commit was additionally verified on a temporary fork CI branch using the repository's unchanged lint/test job matrix: Python 3.11 and 3.12 both passed. Workflow run: https://github.com/Kyomorie/bookbridge/actions/runs/32886725654