### PR TITLE
[Fix] Make database backups WAL-safe and document recovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
     fi
 
 # 3. Create directories
-RUN mkdir -p /app/src /app/templates /app/static /data/audio_cache /data/logs /data/transcripts
+RUN mkdir -p /app/src /app/templates /app/static /app/scripts /data/audio_cache /data/logs /data/transcripts
 
 # 4. Copy Application Code
 COPY src/ /app/src/
@@ -42,9 +42,11 @@ COPY static/ /app/static/
 COPY alembic/ /app/alembic/
 COPY alembic.ini /app/alembic.ini
 COPY plugins/ /app/plugins/
+COPY scripts/backup_db.sh /app/scripts/backup_db.sh
 
 COPY start.sh /app/start.sh
-RUN sed -i 's/\r$//' /app/start.sh && chmod +x /app/start.sh
+RUN sed -i 's/\r$//' /app/start.sh /app/scripts/backup_db.sh && \
+    chmod +x /app/start.sh /app/scripts/backup_db.sh
 
 EXPOSE 5757
 

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,84 @@
+# Backup and Restore
+
+BookBridge keeps its own persistent state under `DATA_DIR` (`/data` in Docker). With the example Compose file, that is the host's `./data` directory.
+
+## What to back up
+
+For disaster recovery, back up the whole `DATA_DIR`, not only `database.db`.
+
+- `database.db` stores mappings, sync state, settings, users, statistics, and computed book alignments.
+- `secret.key` is the default key used to decrypt stored credentials.
+- `audio_cache/` keeps completed local Whisper transcript data (`_progress.json`) after a successful transcription so a later re-alignment can reuse it instead of running Whisper again.
+- The remaining files under `/data` are caches or application state that may save re-download or rebuild work after a restore.
+
+The `/books` mount is library input, not BookBridge state, and should follow your normal library backup policy. The same applies to optional Storyteller or Calibre mounts and to your Compose/environment configuration.
+
+> [!IMPORTANT]
+> A backup that contains both `database.db` and `secret.key` can decrypt BookBridge's stored credentials. Protect it like the server itself.
+
+If you use `BOOKBRIDGE_SECRET_KEY` or `BOOKBRIDGE_SECRET_KEY_FILE`, treat that key as separately managed and preserve the exact value or file outside the normal `/data` backup.
+
+## Recommended: full `/data` backup
+
+The safest simple backup is a filesystem copy while BookBridge is stopped. This keeps the SQLite database, credential key, completed transcript cache, and the rest of the data directory at one point in time.
+
+For the bind mount used by the example Compose file:
+
+```bash
+docker compose stop bookbridge
+tar -czf "bookbridge-data-$(date +%Y%m%d_%H%M%S).tar.gz" -C ./data .
+docker compose start bookbridge
+```
+
+If you use a named volume or a different host path, snapshot or archive that volume instead. Store the resulting archive somewhere outside the BookBridge data disk; a second copy inside `/data` does not protect against disk loss.
+
+## Online database snapshot
+
+For a quick database snapshot without stopping BookBridge, the image includes a small helper:
+
+```bash
+docker compose exec bookbridge /app/scripts/backup_db.sh
+```
+
+The helper uses SQLite's online backup API instead of copying the live database file directly, so committed data in either WAL or rollback-journal mode is included consistently. It also runs `PRAGMA integrity_check` on the snapshot before publishing it.
+
+By default it writes:
+
+```text
+/data/backups/abs_kosync_YYYYMMDD_HHMMSS.db
+/data/backups/abs_kosync_YYYYMMDD_HHMMSS.secret.key
+```
+
+The key file is created only when BookBridge is using the default `DATA_DIR/secret.key`. Explicit `BOOKBRIDGE_SECRET_KEY` and `BOOKBRIDGE_SECRET_KEY_FILE` overrides are deliberately not bundled.
+
+> [!NOTE]
+> This helper is a database snapshot, not a full disaster-recovery backup. It does not include `audio_cache/`, cached EPUBs, external library mounts, or your Compose/environment configuration. Copy snapshots off the BookBridge data disk if you want them to survive host or disk failure.
+
+The database contains the computed alignment maps, so an ordinary database restore keeps existing book alignments. A full `/data` backup also preserves the completed Whisper transcript cache, which is what lets BookBridge rebuild an alignment later without transcribing the audiobook again.
+
+## Restore
+
+Stop BookBridge before replacing its data. For the example bind mount, restore a full archive into an empty `./data` directory; keeping the old directory alongside it gives you an easy rollback if the restore is wrong.
+
+```bash
+docker compose stop bookbridge
+mv ./data ./data.before-restore
+mkdir ./data
+tar -xzf bookbridge-data-YYYYMMDD_HHMMSS.tar.gz -C ./data
+docker compose start bookbridge
+```
+
+If you use an external credential key, restore the same `BOOKBRIDGE_SECRET_KEY` value or `BOOKBRIDGE_SECRET_KEY_FILE` before starting BookBridge.
+
+For a database-only snapshot, stop BookBridge, remove stale SQLite sidecars, then restore the database and matching default key:
+
+```bash
+docker compose stop bookbridge
+rm -f ./data/database.db-wal ./data/database.db-shm ./data/database.db-journal
+cp ./bookbridge-db-backups/abs_kosync_YYYYMMDD_HHMMSS.db ./data/database.db
+cp ./bookbridge-db-backups/abs_kosync_YYYYMMDD_HHMMSS.secret.key ./data/secret.key
+chmod 600 ./data/secret.key
+docker compose start bookbridge
+```
+
+Skip the `secret.key` copy when the snapshot did not contain one because you manage the key externally. Restore into the same BookBridge version when possible; newer versions can migrate an older database forward on startup, while deliberately restoring a newer database into an older BookBridge build is not supported.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,5 +54,6 @@ nav:
   - Getting Started: getting-started.md
   - User Guide: user-guide.md
   - Configuration: configuration.md
+  - Backup & Restore: backup-restore.md
   - Troubleshooting: troubleshooting.md
   - Changelog: changelog.md

--- a/scripts/backup_db.sh
+++ b/scripts/backup_db.sh
@@ -1,23 +1,82 @@
 #!/bin/bash
 # scripts/backup_db.sh
+#
+# Create an online-consistent SQLite snapshot plus the active default
+# credential key. This helper is intentionally narrower than a full DATA_DIR
+# backup; see docs/backup-restore.md for disaster recovery.
 
-# Default to /data if DATA_DIR is not set
+set -euo pipefail
+
 DATA_DIR="${DATA_DIR:-/data}"
-BACKUP_DIR="${DATA_DIR}/backups"
-DB_FILE="database.db"
+BACKUP_DIR="${BACKUP_DIR:-${DATA_DIR}/backups}"
+DB_PATH="${DATA_DIR}/database.db"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
 
-# Create backup directory if it doesn't exist
-mkdir -p "$BACKUP_DIR"
-
-# Timestamp for the backup
-TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
-BACKUP_FILE="${BACKUP_DIR}/abs_kosync_${TIMESTAMP}.db"
-
-# Check if database exists
-if [ -f "${DATA_DIR}/${DB_FILE}" ]; then
-    cp "${DATA_DIR}/${DB_FILE}" "$BACKUP_FILE"
-    echo "✅ Backup created: $BACKUP_FILE"
-else
-    echo "⚠️ Database file not found at ${DATA_DIR}/${DB_FILE}"
+if [ ! -f "$DB_PATH" ]; then
+    echo "⚠️ Database file not found at $DB_PATH"
     exit 1
 fi
+
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+    echo "❌ Python interpreter not found: $PYTHON_BIN"
+    exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+TIMESTAMP="$(date +"%Y%m%d_%H%M%S")"
+BACKUP_FILE="${BACKUP_DIR}/abs_kosync_${TIMESTAMP}.db"
+KEY_BACKUP_FILE="${BACKUP_DIR}/abs_kosync_${TIMESTAMP}.secret.key"
+TMP_BACKUP_FILE="${BACKUP_FILE}.tmp.$$"
+TMP_KEY_BACKUP_FILE="${KEY_BACKUP_FILE}.tmp.$$"
+
+if [ -e "$BACKUP_FILE" ] || [ -e "$KEY_BACKUP_FILE" ]; then
+    echo "❌ Backup target already exists for timestamp $TIMESTAMP"
+    exit 1
+fi
+
+cleanup() {
+    rm -f "$TMP_BACKUP_FILE" "$TMP_KEY_BACKUP_FILE"
+}
+trap cleanup EXIT
+
+"$PYTHON_BIN" - "$DB_PATH" "$TMP_BACKUP_FILE" <<'PY'
+from pathlib import Path
+import sqlite3
+import sys
+
+source_path, backup_path = sys.argv[1:3]
+source_uri = Path(source_path).resolve().as_uri() + "?mode=ro"
+
+with sqlite3.connect(source_uri, uri=True, timeout=60) as source:
+    with sqlite3.connect(backup_path) as backup:
+        source.backup(backup)
+        result = backup.execute("PRAGMA integrity_check").fetchone()
+        if result != ("ok",):
+            raise RuntimeError(f"SQLite integrity_check failed: {result!r}")
+PY
+
+key_message=""
+if [ -n "${BOOKBRIDGE_SECRET_KEY:-}" ]; then
+    key_message="Credential key is provided by BOOKBRIDGE_SECRET_KEY and is not included."
+elif [ -n "${BOOKBRIDGE_SECRET_KEY_FILE:-}" ]; then
+    key_message="Credential key is provided by BOOKBRIDGE_SECRET_KEY_FILE and is not included."
+elif [ -f "${DATA_DIR}/secret.key" ]; then
+    cp "${DATA_DIR}/secret.key" "$TMP_KEY_BACKUP_FILE"
+    chmod 600 "$TMP_KEY_BACKUP_FILE" 2>/dev/null || true
+fi
+
+mv "$TMP_BACKUP_FILE" "$BACKUP_FILE"
+if [ -f "$TMP_KEY_BACKUP_FILE" ]; then
+    mv "$TMP_KEY_BACKUP_FILE" "$KEY_BACKUP_FILE"
+fi
+
+trap - EXIT
+
+echo "✅ Database backup created: $BACKUP_FILE"
+if [ -f "$KEY_BACKUP_FILE" ]; then
+    echo "🔐 Credential key backup created: $KEY_BACKUP_FILE"
+elif [ -n "$key_message" ]; then
+    echo "ℹ️ $key_message"
+fi
+echo "ℹ️ Database snapshot only. Back up the full DATA_DIR to preserve transcript and cache state."

--- a/tests/test_backup_script.py
+++ b/tests/test_backup_script.py
@@ -1,0 +1,124 @@
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPT = _ROOT / "scripts" / "backup_db.sh"
+_BASH = shutil.which("bash")
+
+
+def _run_backup(data_dir: Path, **extra_env):
+    env = os.environ.copy()
+    for key in ("BACKUP_DIR", "BOOKBRIDGE_SECRET_KEY", "BOOKBRIDGE_SECRET_KEY_FILE"):
+        env.pop(key, None)
+    env.update({
+        "DATA_DIR": str(data_dir),
+        "PYTHON_BIN": sys.executable,
+    })
+    env.update(extra_env)
+    return subprocess.run(
+        [_BASH, str(_SCRIPT)],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def _create_minimal_database(data_dir: Path):
+    data_dir.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(data_dir / "database.db") as db:
+        db.execute("CREATE TABLE marker (value TEXT)")
+        db.execute("INSERT INTO marker (value) VALUES ('ready')")
+
+
+@pytest.mark.skipif(_BASH is None, reason="bash is required for the backup helper")
+def test_backup_captures_committed_wal_data(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    db_path = data_dir / "database.db"
+    source = sqlite3.connect(db_path)
+    try:
+        assert source.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+        source.execute("PRAGMA wal_autocheckpoint=0")
+        source.execute("CREATE TABLE marker (value TEXT)")
+        source.commit()
+        source.execute("INSERT INTO marker (value) VALUES ('committed-in-wal')")
+        source.commit()
+
+        wal_path = Path(f"{db_path}-wal")
+        assert wal_path.exists()
+        assert wal_path.stat().st_size > 0
+
+        result = _run_backup(data_dir)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        snapshots = list((data_dir / "backups").glob("abs_kosync_*.db"))
+        assert len(snapshots) == 1
+        with sqlite3.connect(snapshots[0]) as snapshot:
+            rows = snapshot.execute("SELECT value FROM marker").fetchall()
+            assert rows == [("committed-in-wal",)]
+            assert snapshot.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    finally:
+        source.close()
+
+
+@pytest.mark.skipif(_BASH is None, reason="bash is required for the backup helper")
+def test_backup_copies_default_secret_key(tmp_path):
+    data_dir = tmp_path / "data"
+    _create_minimal_database(data_dir)
+    key_path = data_dir / "secret.key"
+    key_path.write_text("test-fernet-key\n", encoding="utf-8")
+    key_path.chmod(0o600)
+
+    result = _run_backup(data_dir)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    key_snapshots = list((data_dir / "backups").glob("abs_kosync_*.secret.key"))
+    assert len(key_snapshots) == 1
+    assert key_snapshots[0].read_text(encoding="utf-8") == "test-fernet-key\n"
+    assert key_snapshots[0].stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.skipif(_BASH is None, reason="bash is required for the backup helper")
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"BOOKBRIDGE_SECRET_KEY": "managed-outside-data"},
+        {"BOOKBRIDGE_SECRET_KEY_FILE": "/run/secrets/bookbridge.key"},
+    ],
+)
+def test_backup_does_not_bundle_external_credential_key(tmp_path, override):
+    data_dir = tmp_path / "data"
+    _create_minimal_database(data_dir)
+    (data_dir / "secret.key").write_text("stale-default-key\n", encoding="utf-8")
+
+    result = _run_backup(data_dir, **override)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert not list((data_dir / "backups").glob("abs_kosync_*.secret.key"))
+    assert next(iter(override)) in result.stdout
+
+
+@pytest.mark.skipif(_BASH is None, reason="bash is required for the backup helper")
+def test_backup_fails_without_database(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    result = _run_backup(data_dir)
+
+    assert result.returncode != 0
+    assert "Database file not found" in result.stdout
+    assert not (data_dir / "backups").exists()
+
+
+def test_backup_helper_is_packaged_in_container_image():
+    dockerfile = (_ROOT / "Dockerfile").read_text(encoding="utf-8")
+    assert "COPY scripts/backup_db.sh /app/scripts/backup_db.sh" in dockerfile
+    assert "chmod +x /app/start.sh /app/scripts/backup_db.sh" in dockerfile


### PR DESCRIPTION
## Summary

Makes BookBridge's existing database backup helper safe to use while the app is running and documents what must be preserved for a real disaster-recovery backup.

The current helper copies `database.db` directly. BookBridge can run SQLite in WAL mode, so that copy can miss committed data that still lives in the WAL. A database-only copy also does not explain that the credential key and completed Whisper transcript cache matter during recovery.

This change:

- uses SQLite's online backup API for a consistent live snapshot in WAL or rollback-journal mode
- runs `PRAGMA integrity_check` before publishing the snapshot
- backs up the default `DATA_DIR/secret.key` beside the database, while leaving explicitly external key overrides external
- packages the existing helper into the container at `/app/scripts/backup_db.sh`
- adds a Backup & Restore guide that recommends the full `DATA_DIR` for disaster recovery
- documents that computed alignments live in the database and completed Whisper transcript state in `audio_cache/_progress.json` can avoid retranscription if an alignment later needs to be rebuilt
- removes stale SQLite `-wal`, `-shm`, and rollback-journal sidecars in the documented database-only restore path

## Scope

Intentionally narrow:

- no sync or leader-selection changes
- no database migration or schema change
- no new dependency
- no automatic backup scheduler
- no change to external library mounts
- existing `abs_kosync_...` snapshot naming is preserved

The branch is based directly on current `dev` (`34f83802fa1ce5e8ae58a143e92baeefee749c9b`) and is one commit ahead with no unrelated changes.

## Tests

Adds regression coverage for:

- committed WAL data being present in the snapshot
- SQLite integrity verification
- default credential-key backup and restrictive permissions
- external credential-key overrides not being bundled
- missing-database failure without creating a misleading backup
- packaging the helper in the Docker image

Because the repository's Python workflow runs for PRs targeting `main` while contribution PRs target `dev`, the exact final source tree was additionally verified on a temporary fork CI commit using the repository's unchanged Python workflow. Lint and the full pytest suite passed on both Python 3.11 and 3.12: https://github.com/Kyomorie/bookbridge/actions/runs/32902798978

Closes #343