### PR TITLE
[Fix] Keep neighboring library cards compact when position preview opens

### DIFF
--- a/static/css/reading-position-preview.css
+++ b/static/css/reading-position-preview.css
@@ -31,6 +31,10 @@
     opacity: 0.65;
 }
 
+.book-grid.position-preview-expanded {
+    align-items: start;
+}
+
 .position-preview-panel {
     min-width: 0;
     margin: 0 0 8px;

--- a/static/js/reading-position-preview.js
+++ b/static/js/reading-position-preview.js
@@ -55,10 +55,20 @@
         document.querySelectorAll('.book-card[data-abs-id]').forEach(createPreviewUi);
     }
 
+    function syncGridPreviewLayout(button) {
+        const grid = button.closest('.book-grid');
+        if (!grid) return;
+        const hasExpandedPreview = Boolean(
+            grid.querySelector('[data-position-preview-toggle][aria-expanded="true"]')
+        );
+        grid.classList.toggle('position-preview-expanded', hasExpandedPreview);
+    }
+
     function setExpanded(button, panel, expanded) {
         button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         button.textContent = expanded ? 'Hide position' : 'Show position';
         panel.hidden = !expanded;
+        syncGridPreviewLayout(button);
     }
 
     function setLoading(panel) {

--- a/tests/test_reading_position_preview_ui.py
+++ b/tests/test_reading_position_preview_ui.py
@@ -38,6 +38,17 @@ def test_preview_script_renders_book_text_as_text_only():
     assert "console.error" not in script
 
 
+def test_expanded_preview_only_disables_grid_stretch_while_needed():
+    script = (ROOT / "static" / "js" / "reading-position-preview.js").read_text(encoding="utf-8")
+    css = (ROOT / "static" / "css" / "reading-position-preview.css").read_text(encoding="utf-8")
+
+    assert "button.closest('.book-grid')" in script
+    assert "[data-position-preview-toggle][aria-expanded=\"true\"]" in script
+    assert "grid.classList.toggle('position-preview-expanded', hasExpandedPreview)" in script
+    assert ".book-grid.position-preview-expanded" in css
+    assert "align-items: start" in css
+
+
 def test_preview_css_uses_existing_bookbridge_tokens_and_has_mobile_layout():
     css = (ROOT / "static" / "css" / "reading-position-preview.css").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

Fixes a small Library layout regression introduced by the expandable reading-position preview.

CSS Grid normally stretches every card in a row to the height of the tallest card. When one card opens its position preview, that made the neighboring cards grow to the same height even though their previews were still closed.

This change keeps the existing equal-height card layout by default, but temporarily switches only the affected `.book-grid` to natural card heights while at least one position preview in that grid is expanded. Closing the last preview restores the normal layout.

## Scope

Intentionally small:

- no backend, API, database, or sync changes
- no change to preview loading or position resolution
- no global change to the normal equal-height Library layout
- multiple open previews in the same grid are handled correctly

## Tests

- focused UI regression assertions cover the scoped grid class and CSS behavior
- `node --check` passes for the modified preview script
- an external browser layout regression check verified actual card heights: equal when closed, only expanded cards grow while previews are open, and equal heights return after the last preview closes

The branch is based directly on current `dev` (`34f83802fa1ce5e8ae58a143e92baeefee749c9b`), one commit ahead and zero behind.