### PR TITLE
[Fix] Preserve real EPUB DOM structure for generated KoSync XPointers

### DIFF
--- a/src/sync_clients/kosync_sync_client.py
+++ b/src/sync_clients/kosync_sync_client.py
@@ -3,6 +3,9 @@ from typing import Optional
 import logging
 import re
 
+from bs4 import BeautifulSoup, Tag
+from lxml import html
+
 from src.api.api_clients import KoSyncClient
 from src.db.models import Book, State
 from src.utils.ebook_utils import EbookParser
@@ -153,6 +156,144 @@ class KoSyncSyncClient(SyncClient):
         block_path = "/".join(normalized_steps[:last_block_idx + 1])
         return f"{prefix}/{block_path}.0"
 
+    def _generated_xpath_exists_in_epub(self, epub: str, xpath: str) -> Optional[bool]:
+        """Return whether a generated block XPath exists in its exact EPUB fragment.
+
+        ``None`` means validation itself was unavailable and deliberately preserves
+        the pre-existing write path. ``False`` is reserved for a definite structural
+        mismatch, which is safe to repair or reject.
+        """
+        match = re.match(r"^/body/DocFragment\[(\d+)\]/(.+)\.0$", str(xpath or ""))
+        if not match:
+            return False
+
+        spine_index = int(match.group(1))
+        relative_path = match.group(2)
+        try:
+            book_path = self.ebook_parser.resolve_book_path(epub)
+            _, spine_map = self.ebook_parser.extract_text_and_map(book_path)
+            target_item = next(
+                (item for item in spine_map if item.get("spine_index") == spine_index),
+                None,
+            )
+            if target_item is None:
+                return False
+
+            tree = html.fromstring(target_item["content"])
+            return bool(tree.xpath(f"./{relative_path}"))
+        except Exception as exc:
+            logger.debug(
+                "KoSync generated XPath validation unavailable for '%s': %s",
+                epub,
+                exc,
+                exc_info=True,
+            )
+            return None
+
+    def _build_dom_preserving_block_xpath(self, epub: str, pct: float) -> Optional[str]:
+        """Build a block-level XPath from the real DOM at a percentage position.
+
+        This is a narrow recovery path for a generated XPath that was proven not to
+        exist in the source EPUB. It mirrors the parser's text-coordinate math, then
+        walks the actual BeautifulSoup parent chain instead of inventing a parent.
+        """
+        try:
+            book_path = self.ebook_parser.resolve_book_path(epub)
+            full_text, spine_map = self.ebook_parser.extract_text_and_map(book_path)
+            if not full_text or not spine_map:
+                return None
+
+            clamped_pct = max(0.0, min(1.0, float(pct)))
+            position = int((len(full_text) - 1) * clamped_pct) if len(full_text) > 1 else 0
+            target_item, clamped_pos = self.ebook_parser._resolve_spine_item_for_position(
+                spine_map,
+                position,
+            )
+            if not target_item:
+                return None
+
+            local_pos = clamped_pos - target_item["start"]
+            soup = BeautifulSoup(target_item["content"], "html.parser")
+            current_char_count = 0
+            target_string = None
+            first_non_empty_string = None
+            last_non_empty_string = None
+
+            for string in soup.find_all(string=True):
+                clean_text = str(string).strip()
+                text_len = len(clean_text)
+                if text_len == 0:
+                    continue
+                if first_non_empty_string is None:
+                    first_non_empty_string = string
+                last_non_empty_string = string
+                if current_char_count + text_len > local_pos:
+                    target_string = string
+                    break
+                current_char_count += text_len
+                if current_char_count <= local_pos:
+                    current_char_count += 1
+
+            if target_string is None:
+                target_string = last_non_empty_string or first_non_empty_string
+            if target_string is None:
+                return None
+
+            anchor = getattr(target_string, "parent", None)
+            structural_tags = self.ebook_parser.CRENGINE_STRUCTURAL_TAGS
+            while anchor is not None:
+                name = getattr(anchor, "name", None)
+                if name in structural_tags:
+                    break
+                if name in ("body", "html", "[document]", None):
+                    return None
+                anchor = getattr(anchor, "parent", None)
+            if anchor is None:
+                return None
+
+            path_segments = []
+            current = anchor
+            found_body = False
+            fragile_tags = self.ebook_parser.CRENGINE_FRAGILE_INLINE_TAGS
+            while current is not None and getattr(current, "name", None) != "[document]":
+                name = getattr(current, "name", None)
+                if name == "body":
+                    path_segments.append("body")
+                    found_body = True
+                    break
+                if not name:
+                    return None
+                if name in fragile_tags:
+                    current = getattr(current, "parent", None)
+                    continue
+
+                parent = getattr(current, "parent", None)
+                siblings = []
+                if parent is not None:
+                    siblings = [
+                        child for child in getattr(parent, "children", [])
+                        if isinstance(child, Tag) and child.name == name
+                    ]
+                if len(siblings) > 1:
+                    path_segments.append(f"{name}[{siblings.index(current) + 1}]")
+                else:
+                    path_segments.append(name)
+                current = parent
+
+            if not found_body:
+                return None
+
+            relative_path = "/".join(reversed(path_segments))
+            return f"/body/DocFragment[{target_item['spine_index']}]/{relative_path}.0"
+        except Exception as exc:
+            logger.debug(
+                "KoSync DOM-preserving XPath recovery failed for '%s': %s",
+                epub,
+                exc,
+                exc_info=True,
+            )
+            return None
+
     def _reset_progress_xpath(self) -> str:
         """Return the service-specific locator used when clearing progress."""
         return ""
@@ -173,6 +314,30 @@ class KoSyncSyncClient(SyncClient):
         if epub and pct is not None and pct > 0:
             sentence_xpath = self.ebook_parser.get_sentence_level_ko_xpath(epub, pct)
             safe_xpath = self._sanitize_kosync_xpath(sentence_xpath, pct)
+
+            # A syntactically plausible generated XPath can still invent DOM
+            # structure (for example body/p when the EPUB is body/div/p). Only a
+            # definite mismatch activates recovery; validation failures themselves
+            # preserve the existing behavior to avoid introducing a new outage mode.
+            if safe_xpath and self._generated_xpath_exists_in_epub(epub, safe_xpath) is False:
+                recovered_xpath = self._build_dom_preserving_block_xpath(epub, pct)
+                recovered_xpath = self._sanitize_kosync_xpath(recovered_xpath, pct)
+                if (
+                    recovered_xpath
+                    and self._generated_xpath_exists_in_epub(epub, recovered_xpath) is True
+                ):
+                    logger.info(
+                        "KoSync generated XPath did not exist in '%s'; using DOM-preserving block anchor %s",
+                        epub,
+                        recovered_xpath,
+                    )
+                    safe_xpath = recovered_xpath
+                else:
+                    logger.warning(
+                        "KoSync generated XPath did not exist in '%s' and no validated DOM fallback was available",
+                        epub,
+                    )
+                    safe_xpath = None
 
         if safe_xpath is None and pct is not None and pct <= 0:
             safe_xpath = self._reset_progress_xpath()

--- a/tests/test_kosync_xpath_safety.py
+++ b/tests/test_kosync_xpath_safety.py
@@ -12,6 +12,30 @@ class TestKoSyncXPathSafety(unittest.TestCase):
         self.ebook_parser = Mock()
         self.client = KoSyncSyncClient(self.kosync_api, self.ebook_parser)
 
+    def _configure_epub_dom(self, content, full_text, *, spine_index=4, clamped_pos=0):
+        item = {
+            "start": 0,
+            "end": len(full_text),
+            "char_len": len(full_text),
+            "spine_index": spine_index,
+            "href": "chapter.xhtml",
+            "content": content,
+        }
+        self.ebook_parser.resolve_book_path.return_value = "/books/book.epub"
+        self.ebook_parser.extract_text_and_map.return_value = (full_text, [item])
+        self.ebook_parser._resolve_spine_item_for_position.return_value = (item, clamped_pos)
+        self.ebook_parser.CRENGINE_STRUCTURAL_TAGS = {
+            "p", "div", "section", "article", "blockquote",
+            "h1", "h2", "h3", "h4", "h5", "h6",
+            "li", "header", "footer", "aside",
+            "td", "th", "dt", "dd", "figcaption", "pre",
+        }
+        self.ebook_parser.CRENGINE_FRAGILE_INLINE_TAGS = {
+            "span", "em", "strong", "b", "i", "u", "a", "font",
+            "small", "big", "sub", "sup",
+        }
+        return item
+
     def test_sanitize_repairs_trailing_slash(self):
         malformed = "/body/DocFragment[9]/body/div[1]/"
         repaired = self.client._sanitize_kosync_xpath(malformed, 0.5)
@@ -48,6 +72,93 @@ class TestKoSyncXPathSafety(unittest.TestCase):
             "/body/DocFragment[24]/body/p[15].0",
         )
 
+    def test_generated_xpath_validation_distinguishes_real_and_invented_parent_chain(self):
+        self._configure_epub_dom(
+            b"<html><body><div><p>First</p><p>Second</p></div></body></html>",
+            "First Second",
+        )
+
+        self.assertTrue(
+            self.client._generated_xpath_exists_in_epub(
+                "book.epub",
+                "/body/DocFragment[4]/body/div/p[2].0",
+            )
+        )
+        self.assertFalse(
+            self.client._generated_xpath_exists_in_epub(
+                "book.epub",
+                "/body/DocFragment[4]/body/p[1].0",
+            )
+        )
+
+    def test_generated_xpath_validation_rejects_malformed_or_missing_fragment(self):
+        self._configure_epub_dom(
+            b"<html><body><p>Readable</p></body></html>",
+            "Readable",
+        )
+
+        self.assertFalse(self.client._generated_xpath_exists_in_epub("book.epub", "bad-xpath"))
+        self.assertFalse(
+            self.client._generated_xpath_exists_in_epub(
+                "book.epub",
+                "/body/DocFragment[99]/body/p.0",
+            )
+        )
+
+    def test_generated_xpath_validation_failure_is_unknown_not_false(self):
+        self.ebook_parser.resolve_book_path.side_effect = RuntimeError("temporary parse failure")
+
+        self.assertIsNone(
+            self.client._generated_xpath_exists_in_epub(
+                "book.epub",
+                "/body/DocFragment[4]/body/p.0",
+            )
+        )
+
+    def test_dom_fallback_preserves_nested_parent_chain_and_sibling_index(self):
+        self._configure_epub_dom(
+            b"<html><body><section><div>"
+            b"<p><span>Alpha</span></p>"
+            b"<p><span>Bravo Charlie</span></p>"
+            b"</div></section></body></html>",
+            "Alpha Bravo Charlie",
+            clamped_pos=8,
+        )
+
+        xpath = self.client._build_dom_preserving_block_xpath("book.epub", 0.5)
+
+        self.assertEqual(xpath, "/body/DocFragment[4]/body/section/div/p[2].0")
+
+    def test_dom_fallback_handles_direct_body_block(self):
+        self._configure_epub_dom(
+            b"<html><body><p>Readable text</p></body></html>",
+            "Readable text",
+            clamped_pos=2,
+        )
+
+        xpath = self.client._build_dom_preserving_block_xpath("book.epub", 0.2)
+
+        self.assertEqual(xpath, "/body/DocFragment[4]/body/p.0")
+
+    def test_dom_fallback_returns_none_without_readable_or_structural_anchor(self):
+        self._configure_epub_dom(
+            b"<html><body><div></div></body></html>",
+            "x",
+        )
+        self.assertIsNone(self.client._build_dom_preserving_block_xpath("book.epub", 0.5))
+
+        self._configure_epub_dom(
+            b"<html><body><main>Readable text</main></body></html>",
+            "Readable text",
+            clamped_pos=2,
+        )
+        self.assertIsNone(self.client._build_dom_preserving_block_xpath("book.epub", 0.5))
+
+    def test_dom_fallback_returns_none_when_epub_mapping_is_unavailable(self):
+        self.ebook_parser.resolve_book_path.side_effect = RuntimeError("temporary parse failure")
+
+        self.assertIsNone(self.client._build_dom_preserving_block_xpath("book.epub", 0.5))
+
     def test_update_progress_skips_malformed_xpath_when_unrecoverable(self):
         self.ebook_parser.get_sentence_level_ko_xpath.return_value = None
         book = SimpleNamespace(kosync_doc_id="doc-1", ebook_filename="book.epub", abs_title="Book")
@@ -73,6 +184,90 @@ class TestKoSyncXPathSafety(unittest.TestCase):
         self.kosync_api.update_progress.assert_called_once_with(
             "doc-2",
             0.73,
+            "/body/DocFragment[4]/body/p[1].0",
+        )
+
+    def test_update_progress_repairs_invented_parent_chain_before_write(self):
+        self._configure_epub_dom(
+            b"<html><body><div>"
+            b"<p><span>Alpha</span></p>"
+            b"<p><span>Bravo Charlie</span></p>"
+            b"</div></body></html>",
+            "Alpha Bravo Charlie",
+            clamped_pos=8,
+        )
+        self.ebook_parser.get_sentence_level_ko_xpath.return_value = (
+            "/body/DocFragment[4]/body/p[1]/text().0"
+        )
+        self.kosync_api.update_progress.return_value = True
+        book = SimpleNamespace(kosync_doc_id="doc-dom", ebook_filename="book.epub", abs_title="Book")
+        request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.5, xpath="ignored"))
+
+        result = self.client.update_progress(book, request)
+
+        self.assertTrue(result.success)
+        self.kosync_api.update_progress.assert_called_once_with(
+            "doc-dom",
+            0.5,
+            "/body/DocFragment[4]/body/div/p[2].0",
+        )
+        self.assertEqual(result.updated_state["xpath"], "/body/DocFragment[4]/body/div/p[2].0")
+
+    def test_update_progress_skips_when_invalid_generated_xpath_cannot_be_repaired(self):
+        self._configure_epub_dom(
+            b"<html><body><main>Readable text</main></body></html>",
+            "Readable text",
+            clamped_pos=2,
+        )
+        self.ebook_parser.get_sentence_level_ko_xpath.return_value = (
+            "/body/DocFragment[4]/body/p[1]/text().0"
+        )
+        book = SimpleNamespace(kosync_doc_id="doc-no-anchor", ebook_filename="book.epub", abs_title="Book")
+        request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.5, xpath="ignored"))
+
+        result = self.client.update_progress(book, request)
+
+        self.assertFalse(result.success)
+        self.assertTrue(result.updated_state["skipped"])
+        self.kosync_api.update_progress.assert_not_called()
+
+    def test_update_progress_keeps_valid_generated_parent_chain(self):
+        self._configure_epub_dom(
+            b"<html><body><div><p>Readable text</p></div></body></html>",
+            "Readable text",
+            clamped_pos=2,
+        )
+        self.ebook_parser.get_sentence_level_ko_xpath.return_value = (
+            "/body/DocFragment[4]/body/div/p/text().0"
+        )
+        self.kosync_api.update_progress.return_value = True
+        book = SimpleNamespace(kosync_doc_id="doc-valid", ebook_filename="book.epub", abs_title="Book")
+        request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.5, xpath="ignored"))
+
+        result = self.client.update_progress(book, request)
+
+        self.assertTrue(result.success)
+        self.kosync_api.update_progress.assert_called_once_with(
+            "doc-valid",
+            0.5,
+            "/body/DocFragment[4]/body/div/p.0",
+        )
+
+    def test_update_progress_validation_error_preserves_existing_write_path(self):
+        self.ebook_parser.get_sentence_level_ko_xpath.return_value = (
+            "/body/DocFragment[4]/body/p[1]/text().0"
+        )
+        self.ebook_parser.resolve_book_path.side_effect = RuntimeError("temporary parse failure")
+        self.kosync_api.update_progress.return_value = True
+        book = SimpleNamespace(kosync_doc_id="doc-fail-open", ebook_filename="book.epub", abs_title="Book")
+        request = UpdateProgressRequest(locator_result=LocatorResult(percentage=0.5, xpath="ignored"))
+
+        result = self.client.update_progress(book, request)
+
+        self.assertTrue(result.success)
+        self.kosync_api.update_progress.assert_called_once_with(
+            "doc-fail-open",
+            0.5,
             "/body/DocFragment[4]/body/p[1].0",
         )
 


### PR DESCRIPTION
## Summary

A generated KoSync XPointer can be syntactically valid but structurally impossible for the source EPUB. In the reproduced case the EPUB fragment was `body -> div -> p`, while BookBridge's chapter fallback emitted `body/p[1]`. KOReader could not resolve that incoming locator, opened at the beginning, then reported the resulting near-zero position back to KoSync.

This PR hardens the KoSync write choke point:

- validate the generated block-level XPath against the exact source EPUB fragment before writing it;
- only on a definite structural mismatch, reconstruct a block anchor from the same percentage using the real BeautifulSoup parent chain;
- preserve every real non-fragile parent and same-tag sibling index (`body/div/p[16]`, etc.);
- validate the recovered XPath before allowing the write;
- skip the positive-progress write if no real validated structural anchor exists;
- treat a validation infrastructure error as `unknown` and preserve the existing write path, so the guard cannot create a new outage mode;
- leave clear-progress (`pct <= 0`) semantics unchanged.

## Root cause / reproduction

The real EPUB used for reproduction had a fragment structurally equivalent to:

```html
<body>
  <div>
    <p>...</p>
  </div>
</body>
```

Before the fix, the generated/sanitized locator was equivalent to:

```text
/body/DocFragment[56]/body/p[1].0
```

A native KOReader position on the same EPUB contained the missing parent:

```text
/body/DocFragment[56]/body/div/p[1].0
```

The issue was reproduced on the official `v7.5.0` image with the same KOReader content hash on both sides, ruling out a cross-EPUB/hash mismatch.

## Live validation

On the same official `v7.5.0` installation, the DOM-preserving recovery produced and wrote a locator with the real parent chain, e.g.:

```text
/body/DocFragment[56]/body/div/p[16].0
```

KOReader then pulled that position and opened at the correct reading location instead of the beginning. No near-zero progress write-back followed.

## Tests

`tests/test_kosync_xpath_safety.py` now covers:

- real vs invented parent chains;
- malformed and missing fragments;
- validation-error fail-open behavior;
- nested inline text while preserving structural parents;
- same-tag sibling indexing;
- direct-body block anchors;
- no-readable-anchor and no-structural-anchor cases;
- recovery of the exact `body/p` vs `body/div/p` defect before the KoSync write;
- safe skip when recovery cannot produce a validated anchor;
- valid generated locators remaining unchanged;
- existing malformed/inline/clear-progress behavior.

No migration, schema, API, hash, leader-selection, furthest-wins, or plugin changes.