### PR TITLE
[Fix] Distinguish ABS rewind policy skips from writes

### DIFF
--- a/src/sync_clients/abs_sync_client.py
+++ b/src/sync_clients/abs_sync_client.py
@@ -278,7 +278,8 @@ class ABSSyncClient(SyncClient):
                 logger.info(f"🔄 '{book_title}' Not updating ABS progress — target timestamp {ts_for_text:.2f}s is before current ABS position {abs_ts:.2f}s")
                 return SyncResult(abs_ts, True, {
                     'ts': abs_ts,
-                    'pct': self._abs_to_percentage(abs_ts, book) or 0
+                    'pct': self._abs_to_percentage(abs_ts, book) or 0,
+                    'skipped': True,
                 })
 
             prev_ts = abs_ts if abs_ts is not None else 0.0

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -3300,6 +3300,17 @@ class SyncManager:
             )
             return None
 
+    @staticmethod
+    def _sync_result_was_applied(result) -> bool:
+        """Return True only when a successful result represents a real remote write."""
+        if not result or not getattr(result, 'success', False):
+            return False
+        updated_state = getattr(result, 'updated_state', None)
+        return not (
+            isinstance(updated_state, dict)
+            and bool(updated_state.get('skipped'))
+        )
+
     def _record_bridge_write(self, client_name: str, abs_id: str, result) -> None:
         """Record that BookBridge itself produced this client's current position.
 
@@ -3309,7 +3320,7 @@ class SyncManager:
         client's own axis via SyncResult.updated_state['pct'], so audio and ebook
         clients each record a value comparable with what they will report next."""
         try:
-            if not result or not getattr(result, 'success', False):
+            if not self._sync_result_was_applied(result):
                 return
             updated_state = getattr(result, 'updated_state', None)
             pct = updated_state.get('pct') if isinstance(updated_state, dict) else None
@@ -4113,7 +4124,7 @@ class SyncManager:
 
                 # Save sync results from other clients
                 for client_name, result in results.items():
-                    if result.success:
+                    if self._sync_result_was_applied(result):
                         # Use updated_state if provided, otherwise fall back to basic state
                         state_data = result.updated_state if result.updated_state else {'pct': result.location}
                         logger.info(f"'{abs_id}' '{title_snip}' Updated state data for '{client_name}': {state_data}")

--- a/tests/test_abs_policy_skip_result.py
+++ b/tests/test_abs_policy_skip_result.py
@@ -1,0 +1,61 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from src.sync_clients.abs_sync_client import ABSSyncClient
+from src.sync_clients.sync_client_interface import LocatorResult, SyncResult, UpdateProgressRequest
+from src.sync_manager import SyncManager
+
+
+class ABSPolicySkipResultTestCase(unittest.TestCase):
+    def test_backward_abs_policy_skip_is_successful_but_not_applied(self):
+        abs_api = Mock()
+        abs_api.get_progress.return_value = {"currentTime": 700.0}
+        alignment = Mock()
+        alignment.get_time_for_text.return_value = 550.0
+        client = ABSSyncClient(abs_api, Mock(), Mock(), alignment_service=alignment)
+        book = SimpleNamespace(
+            abs_id="book-1",
+            abs_title="Test Book",
+            transcript_file="DB_MANAGED",
+            duration=1000.0,
+        )
+        request = UpdateProgressRequest(
+            locator_result=LocatorResult(percentage=0.55, match_index=123),
+            txt="target text",
+        )
+
+        result = client.update_progress(book, request)
+
+        self.assertTrue(result.success)
+        self.assertTrue(result.updated_state.get("skipped"))
+        self.assertEqual(result.location, 700.0)
+        self.assertEqual(result.updated_state.get("ts"), 700.0)
+        self.assertAlmostEqual(result.updated_state.get("pct"), 0.7)
+        abs_api.update_progress.assert_not_called()
+
+    def test_skipped_success_is_not_an_applied_write(self):
+        result = SyncResult(700.0, True, {"ts": 700.0, "pct": 0.7, "skipped": True})
+        self.assertFalse(SyncManager._sync_result_was_applied(result))
+
+    def test_normal_success_is_an_applied_write(self):
+        result = SyncResult(700.0, True, {"ts": 700.0, "pct": 0.7})
+        self.assertTrue(SyncManager._sync_result_was_applied(result))
+
+    def test_skipped_success_does_not_stamp_own_write_marker(self):
+        manager = SyncManager.__new__(SyncManager)
+        result = SyncResult(700.0, True, {"ts": 700.0, "pct": 0.7, "skipped": True})
+        with patch("src.services.write_tracker.record_write") as record_write:
+            manager._record_bridge_write("ABS", "book-1", result)
+        record_write.assert_not_called()
+
+    def test_normal_success_still_stamps_own_write_marker(self):
+        manager = SyncManager.__new__(SyncManager)
+        result = SyncResult(700.0, True, {"ts": 700.0, "pct": 0.7})
+        with patch("src.services.write_tracker.record_write") as record_write:
+            manager._record_bridge_write("ABS", "book-1", result)
+        record_write.assert_called_once_with("ABS", "book-1", 0.7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- mark the existing ABS monotonic rewind refusal as a deliberate `skipped` result while keeping `success=True`
- only stamp own-write provenance and persist follower state when a successful result represents an applied remote write
- preserve the existing ABS rewind guard and explicit 0% Clear Progress behavior

## Why

Follow-up to #215 and the maintainer discussion there. `ABSSyncClient.update_progress()` currently returns the unchanged ABS position with `success=True` when it deliberately blocks a backward write. `SyncManager` then treats that non-write as applied, stamps own-write provenance, and persists follower state.

This PR fixes only that result semantics. It does **not** add the pending rewind approval flow discussed in #215.

## Tests

- blocked ABS rewind is successful-but-skipped and performs no ABS update
- skipped successful results are not considered applied
- skipped results do not stamp own-write provenance
- normal successful writes are still considered applied and still stamp provenance

Refs #215.