### PR TITLE
[Fix] Send Audiobookshelf completion through session progress events

### DIFF
--- a/src/api/api_clients.py
+++ b/src/api/api_clients.py
@@ -551,11 +551,96 @@ class ABSClient:
             logger.debug("ABS item_exists error for item %s: %s", item_id, e, exc_info=True)
             return None
 
+    @staticmethod
+    def _positive_number(value) -> float | None:
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            return None
+        return number if number > 0 else None
+
+    def _completion_duration(self, abs_id: str, progress: dict | None = None) -> float | None:
+        """Resolve the authoritative ABS duration used for a completion sync."""
+        duration = self._positive_number((progress or {}).get("duration"))
+        if duration is not None:
+            return duration
+
+        details = self.get_item_details(abs_id) or {}
+        media = details.get("media") or {}
+        return self._positive_number(media.get("duration"))
+
+    @staticmethod
+    def _session_update_succeeded(result) -> bool:
+        return isinstance(result, dict) and bool(result.get("success"))
+
+    def _refresh_finished_progress_event(self, abs_id: str) -> None:
+        """Best-effort session sync of an already-finished item at its current position.
+
+        Audiobookshelf's direct progress endpoint emits ``user_updated`` while
+        playback-session sync emits ``user_item_progress_updated``. Some clients
+        subscribe only to the latter. Re-syncing the unchanged currentTime after
+        the explicit finished flag is set carries that flag through the normal
+        progress event without adding listening time or moving the position.
+        """
+        progress = self.get_progress(abs_id)
+        if not progress or not progress.get("isFinished"):
+            logger.warning(
+                "⚠️ ABS completion was not readable as finished after direct update; "
+                "skipping session refresh for '%s'",
+                abs_id,
+            )
+            return
+
+        try:
+            current_time = float(progress.get("currentTime"))
+        except (TypeError, ValueError):
+            logger.warning(
+                "⚠️ ABS completion has no usable currentTime; skipping session refresh for '%s'",
+                abs_id,
+            )
+            return
+
+        result = self.update_progress(abs_id, current_time, 0.0)
+        if not self._session_update_succeeded(result):
+            logger.warning(
+                "⚠️ ABS item '%s' was marked finished, but the follow-up session refresh failed",
+                abs_id,
+            )
+
     def mark_finished(self, abs_id):
-        """Mark an ABS item as finished."""
+        """Mark an ABS item finished and notify session-progress subscribers."""
         if not self.is_configured():
             logger.error("❌ Cannot mark ABS item finished: ABS is not configured")
             return False
+
+        # Prefer the same playback-session path as ordinary progress writes. ABS
+        # emits user_item_progress_updated for this path, which keeps official and
+        # third-party clients current without polling. A zero timeListened value is
+        # deliberate: completion propagated from reading is not listening time.
+        progress = self.get_progress(abs_id)
+        duration = self._completion_duration(abs_id, progress)
+        if duration is not None:
+            session_result = self.update_progress(abs_id, duration, 0.0)
+            if self._session_update_succeeded(session_result):
+                confirmed = self.get_progress(abs_id)
+                if confirmed and confirmed.get("isFinished"):
+                    logger.info(f"✅ Marked ABS item as finished via session sync: {abs_id}")
+                    return True
+                logger.debug(
+                    "ABS session reached the end for '%s' but did not set isFinished; "
+                    "falling back to an explicit progress update",
+                    abs_id,
+                )
+            else:
+                logger.warning(
+                    "⚠️ ABS session-based completion failed for '%s'; falling back to an explicit progress update",
+                    abs_id,
+                )
+        else:
+            logger.warning(
+                "⚠️ ABS item '%s' has no usable duration; falling back to an explicit progress update",
+                abs_id,
+            )
 
         self._update_session_headers()
         url = f"{self.base_url}/api/me/progress/{abs_id}"
@@ -565,6 +650,12 @@ class ABSClient:
             r = self.session.patch(url, json=payload, timeout=self.timeout)
             if r.status_code in (200, 204):
                 logger.info(f"✅ Marked ABS item as finished: {abs_id}")
+                # If the session path could not establish completion (for example
+                # a library configured to mark finished at exactly 100%), the
+                # explicit PATCH is authoritative. Refresh the unchanged position
+                # through a session so clients that only consume
+                # user_item_progress_updated receive the finished flag as well.
+                self._refresh_finished_progress_event(abs_id)
                 return True
 
             logger.error(f"❌ Failed to mark ABS item finished: {r.status_code} - {sanitize_log_data(r.text)}")

--- a/tests/test_abs_completion_session_sync.py
+++ b/tests/test_abs_completion_session_sync.py
@@ -1,0 +1,111 @@
+"""Regression tests for Audiobookshelf completion propagation.
+
+ABS emits ``user_item_progress_updated`` for playback-session syncs, while the
+plain ``/api/me/progress`` update used by completion propagation emits a
+different user event. Completion should therefore prefer the existing session
+path, while retaining the explicit finished-flag update as a fallback.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.api.api_clients import ABSClient
+
+
+class TestABSCompletionSessionSync(unittest.TestCase):
+    def setUp(self):
+        self.client = ABSClient()
+        self.client.is_configured = MagicMock(return_value=True)
+        self.client._update_session_headers = MagicMock()
+
+    def test_completion_prefers_session_sync_to_abs_duration(self):
+        self.client.get_progress = MagicMock(side_effect=[
+            {"duration": 120.0, "currentTime": 95.0, "isFinished": False},
+            {"duration": 120.0, "currentTime": 120.0, "isFinished": True},
+        ])
+        self.client.update_progress = MagicMock(return_value={"success": True, "code": 200})
+        self.client.session.patch = MagicMock()
+
+        self.assertTrue(self.client.mark_finished("book-1"))
+
+        self.client.update_progress.assert_called_once_with("book-1", 120.0, 0.0)
+        self.client.session.patch.assert_not_called()
+
+    def test_completion_uses_item_duration_when_progress_has_none(self):
+        self.client.get_progress = MagicMock(side_effect=[
+            {"duration": None, "currentTime": 95.0, "isFinished": False},
+            {"duration": 120.0, "currentTime": 120.0, "isFinished": True},
+        ])
+        self.client.get_item_details = MagicMock(return_value={"media": {"duration": 120}})
+        self.client.update_progress = MagicMock(return_value={"success": True, "code": 200})
+        self.client.session.patch = MagicMock()
+
+        self.assertTrue(self.client.mark_finished("book-1"))
+
+        self.client.get_item_details.assert_called_once_with("book-1")
+        self.client.update_progress.assert_called_once_with("book-1", 120.0, 0.0)
+        self.client.session.patch.assert_not_called()
+
+    def test_explicit_finished_fallback_is_kept_when_session_does_not_finish(self):
+        self.client.get_progress = MagicMock(side_effect=[
+            {"duration": 120.0, "currentTime": 95.0, "isFinished": False},
+            {"duration": 120.0, "currentTime": 120.0, "isFinished": False},
+        ])
+        self.client.update_progress = MagicMock(return_value={"success": True, "code": 200})
+        self.client._refresh_finished_progress_event = MagicMock()
+        self.client.session.patch = MagicMock(return_value=SimpleNamespace(status_code=200, text=""))
+
+        self.assertTrue(self.client.mark_finished("book-1"))
+
+        self.client.update_progress.assert_called_once_with("book-1", 120.0, 0.0)
+        self.client.session.patch.assert_called_once()
+        _, kwargs = self.client.session.patch.call_args
+        self.assertEqual(kwargs["json"], {"isFinished": True})
+        self.client._refresh_finished_progress_event.assert_called_once_with("book-1")
+
+    def test_missing_duration_falls_back_to_explicit_finished_update(self):
+        self.client.get_progress = MagicMock(return_value={
+            "duration": None,
+            "currentTime": 95.0,
+            "isFinished": False,
+        })
+        self.client.get_item_details = MagicMock(return_value={"media": {"duration": 0}})
+        self.client.update_progress = MagicMock()
+        self.client._refresh_finished_progress_event = MagicMock()
+        self.client.session.patch = MagicMock(return_value=SimpleNamespace(status_code=204, text=""))
+
+        self.assertTrue(self.client.mark_finished("book-1"))
+
+        self.client.update_progress.assert_not_called()
+        self.client.session.patch.assert_called_once()
+        self.client._refresh_finished_progress_event.assert_called_once_with("book-1")
+
+    def test_finished_fallback_refreshes_same_position_without_listening_credit(self):
+        self.client.get_progress = MagicMock(return_value={
+            "duration": 120.0,
+            "currentTime": 95.5,
+            "isFinished": True,
+        })
+        self.client.update_progress = MagicMock(return_value={"success": True, "code": 200})
+
+        self.client._refresh_finished_progress_event("book-1")
+
+        self.client.update_progress.assert_called_once_with("book-1", 95.5, 0.0)
+
+    def test_finished_fallback_remains_successful_if_event_refresh_fails(self):
+        self.client.get_progress = MagicMock(return_value={
+            "duration": 120.0,
+            "currentTime": 95.5,
+            "isFinished": True,
+        })
+        self.client.get_item_details = MagicMock(return_value={"media": {"duration": 0}})
+        self.client.update_progress = MagicMock(return_value={"success": False, "code": 500})
+        self.client.session.patch = MagicMock(return_value=SimpleNamespace(status_code=200, text=""))
+
+        with patch("src.api.api_clients.logger.warning"):
+            self.assertTrue(self.client.mark_finished("book-1"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Completion propagation currently takes a different Audiobookshelf write path from ordinary progress updates.

Normal ABS progress already uses `/play` -> `/api/session/:id/sync` -> `/close`, but `_propagate_completion()` calls `ABSClient.mark_finished()`, which writes `PATCH /api/me/progress/:id {"isFinished": true}` directly.

That distinction matters to clients. In current Audiobookshelf, the direct progress controller emits `user_updated`, while playback-session sync emits `user_item_progress_updated`. Clients that consume the latter for live progress (for example YAABSA) therefore see the final position update but can miss the subsequent `isFinished=true` transition until they do a full refresh.

This is closely related to the endpoint distinction already identified in #34 / advplyr/audiobookshelf#4977. #374 later introduced completion propagation through `mark_finished()`, and #378 hardened that path without changing the endpoint used for the actual finished transition.

## Change

- Prefer BookBridge's existing session-sync path for ABS completion.
- Resolve the target from ABS's own duration (`/api/me/progress/:id`, falling back to item metadata) rather than the ebook/audio alignment endpoint.
- Sync to the ABS duration with `timeListened: 0`, so reading-driven completion does not create listening credit.
- Read back progress and only treat the session path as complete when ABS reports `isFinished=true`.
- Keep the direct `PATCH {"isFinished": true}` as a correctness fallback when duration is unavailable, session sync fails, or the ABS library's finish policy does not mark 100% as finished.
- After that fallback, best-effort re-sync the *unchanged* current time with zero listening credit. This carries the already-set finished flag through `user_item_progress_updated` without moving the position.

The fallback is important for configurations such as an ABS library set to mark finished at exactly 100%, where its current strict threshold comparison can leave a session at 100% without setting `isFinished`.

## Tests

Added regression coverage for:

- session completion to the ABS-reported duration
- duration fallback to item metadata
- explicit finished-flag fallback when session sync reaches the end but does not finish
- missing-duration fallback
- same-position/zero-listening event refresh after explicit completion
- completion remaining successful when the best-effort event refresh fails

I also checked for an active issue/PR covering this specific completion-event gap and did not find one; the closest prior work is #34, #374 and #378.
