### PR TITLE
[Fix] Route Grimmory ebook covers through book media endpoint

### DIFF
--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -2002,6 +2002,13 @@ class BookloreClient:
             return None, None
         return response.content, response.headers.get('Content-Type', 'image/jpeg')
 
+    def get_book_cover_bytes(self, book_id):
+        """Return a regular Grimmory book cover without exposing credentials."""
+        response = self._make_request("GET", f"/api/v1/media/book/{book_id}/cover")
+        if not response or response.status_code != 200:
+            return None, None
+        return response.content, response.headers.get('Content-Type', 'image/jpeg')
+
     def download_book_to_path(self, book_id, output_path, expected_size: int = 0) -> bool:
         """Stream-download the audiobook file directly to disk.
 
@@ -3159,4 +3166,3 @@ class BookloreClient:
             )
             return False
         return True
-

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -4989,14 +4989,15 @@ def _browser_cover_url(
         return raw
 
     source = (audio_source or "").strip()
+    normalized_audio_source = _normalize_text_source_type(source)
     src_id = (audio_source_id or "").strip()
     aid = (abs_id or "").strip()
 
-    if source == "BookLore" and src_id:
+    if normalized_audio_source == "Booklore" and src_id:
         return f"/api/booklore/audiobook-cover/{src_id}"
-    if source == "BookOrbit" and src_id:
+    if normalized_audio_source == "BookOrbit" and src_id:
         return f"/api/bookorbit/audiobook-cover/{src_id}"
-    if source not in _LIBRARY_AUDIO_SOURCES:
+    if normalized_audio_source not in ("Booklore", "BookOrbit"):
         proxy_id = aid or src_id
         if proxy_id and not _is_synthetic_bridge_key(proxy_id):
             return f"/api/cover-proxy/{proxy_id}"
@@ -5004,9 +5005,10 @@ def _browser_cover_url(
     ebook_src = (ebook_source or "").strip()
     ebook_id = (ebook_source_id or "").strip()
     if ebook_id:
-        if ebook_src == "BookLore":
-            return f"/api/booklore/audiobook-cover/{ebook_id}"
-        if ebook_src == "BookOrbit":
+        normalized_ebook_source = _normalize_text_source_type(ebook_src)
+        if normalized_ebook_source == "Booklore":
+            return f"/api/booklore/book-cover/{ebook_id}"
+        if normalized_ebook_source == "BookOrbit":
             return f"/api/bookorbit/audiobook-cover/{ebook_id}"
     return ""
 
@@ -11076,6 +11078,38 @@ def proxy_booklore_audiobook_cover(book_id):
         return "Error loading cover", 500
 
 
+def proxy_booklore_book_cover(book_id):
+    """Stream a regular Grimmory ebook cover through the backend."""
+    user = current_user()
+    # Older mappings use each of these spellings. Keep the ownership gate
+    # source-agnostic while the client request remains server-side.
+    book = None
+    if database_service:
+        for source in ("BookLore", "Booklore", "Grimmory"):
+            book = database_service.get_book_by_ebook_source(source, str(book_id))
+            if book:
+                break
+    if book and book.abs_id:
+        if not _user_may_modify_book(user, book.abs_id):
+            return _forbidden_book_response(json_response=True)
+    elif user is not None and not getattr(user, 'is_admin', False):
+        return _forbidden_book_response(json_response=True)
+
+    client = container.booklore_client()
+    if not client.is_configured():
+        return "Grimmory not configured", 400
+
+    try:
+        content, content_type = client.get_book_cover_bytes(book_id)
+        if not content:
+            return "Cover not found", 404
+        from flask import Response
+        return Response(content, content_type=content_type or "image/jpeg")
+    except Exception as e:
+        logger.error(f"❌ Error proxying Grimmory book cover for '{book_id}': {e}", exc_info=True)
+        return "Error loading cover", 500
+
+
 def proxy_bookorbit_audiobook_cover(book_id):
     """Stream a BookOrbit book cover through the backend."""
     user = current_user()
@@ -12514,6 +12548,7 @@ def create_app(test_container=None):
     app.add_url_rule('/api/cache/clean', 'clean_cache', clean_inactive_cache, methods=['POST'])
     app.add_url_rule('/api/cover-proxy/<abs_id>', 'proxy_cover', proxy_cover)
     app.add_url_rule('/api/booklore/audiobook-cover/<book_id>', 'proxy_booklore_audiobook_cover', proxy_booklore_audiobook_cover, methods=['GET'])
+    app.add_url_rule('/api/booklore/book-cover/<book_id>', 'proxy_booklore_book_cover', proxy_booklore_book_cover, methods=['GET'])
     app.add_url_rule('/api/bookorbit/audiobook-cover/<book_id>', 'proxy_bookorbit_audiobook_cover', proxy_bookorbit_audiobook_cover, methods=['GET'])
     app.add_url_rule('/api/kavita/cover/<series_id>', 'proxy_kavita_cover', proxy_kavita_cover, methods=['GET'])
     app.add_url_rule('/api/booklore/libraries', 'get_booklore_libraries', get_booklore_libraries, methods=['GET'])

--- a/tests/test_booklore_client.py
+++ b/tests/test_booklore_client.py
@@ -1067,6 +1067,28 @@ def test_get_audiobook_cover_bytes_uses_plural_endpoint(booklore_client):
     booklore_client._make_request.assert_called_once_with("GET", "/api/v1/audiobooks/6043/cover")
 
 
+def test_get_book_cover_bytes_uses_media_book_endpoint(booklore_client):
+    response = MagicMock()
+    response.status_code = 200
+    response.content = b"cover"
+    response.headers = {"Content-Type": "image/webp"}
+    booklore_client._make_request = MagicMock(return_value=response)
+
+    content, content_type = booklore_client.get_book_cover_bytes(4)
+
+    assert content == b"cover"
+    assert content_type == "image/webp"
+    booklore_client._make_request.assert_called_once_with("GET", "/api/v1/media/book/4/cover")
+
+
+def test_get_book_cover_bytes_returns_empty_for_non_success(booklore_client):
+    response = MagicMock()
+    response.status_code = 404
+    booklore_client._make_request = MagicMock(return_value=response)
+
+    assert booklore_client.get_book_cover_bytes(4) == (None, None)
+
+
 def test_add_to_shelf_404_evicts_stale_hydrated_entry(booklore_client):
     booklore_client._process_book_detail(make_detail("gone", title="Gone Book", filename="gone.epub"))
     booklore_client._cache_timestamp = time.time()

--- a/tests/test_dashboard_cover_url_exposure.py
+++ b/tests/test_dashboard_cover_url_exposure.py
@@ -170,11 +170,31 @@ class TestEbookOnlyCoverDerivation(unittest.TestCase):
         _assert_browser_safe(self, result)
 
     def test_grimmory_ebook_source_derives_same_origin_cover(self):
-        result = self.sanitize(
-            None, abs_id="ebook-abc123",
-            ebook_source="BookLore", ebook_source_id="42",
-        )
-        self.assertEqual(result, "/api/booklore/audiobook-cover/42")
+        for source in ("BookLore", "Booklore", "Grimmory"):
+            with self.subTest(source=source):
+                result = self.sanitize(
+                    None, abs_id="ebook-abc123",
+                    ebook_source=source, ebook_source_id="4",
+                )
+                self.assertEqual(result, "/api/booklore/book-cover/4")
+
+    def test_grimmory_cbz_and_epub_ebooks_use_the_regular_book_proxy(self):
+        for filename in ("De Vliegende Aap.cbz", "book.epub"):
+            with self.subTest(filename=filename):
+                result = self.sanitize(
+                    None, abs_id="ebook-abc123", ebook_source="Grimmory",
+                    ebook_source_id="4",
+                )
+                self.assertEqual(result, "/api/booklore/book-cover/4")
+
+    def test_grimmory_audiobook_keeps_the_audiobook_proxy(self):
+        for source in ("BookLore", "Grimmory"):
+            with self.subTest(source=source):
+                result = self.sanitize(
+                    None, audio_source=source, audio_source_id="9",
+                    ebook_source="Grimmory", ebook_source_id="4",
+                )
+                self.assertEqual(result, "/api/booklore/audiobook-cover/9")
 
     def test_audio_cover_still_wins_over_the_ebook_library(self):
         """A matched book keeps its audiobook art; the ebook is only a fallback."""

--- a/tests/test_multiuser_auth.py
+++ b/tests/test_multiuser_auth.py
@@ -1544,6 +1544,9 @@ class TestCoverProxyUserIsolation(unittest.TestCase):
         self.mock_container.mock_booklore_client.get_audiobook_cover_bytes.return_value = (
             b"booklore-cover", "image/jpeg",
         )
+        self.mock_container.mock_booklore_client.get_book_cover_bytes.return_value = (
+            b"book-cover", "image/webp",
+        )
         self.mock_container.mock_bookorbit_client.is_configured.return_value = True
         self.mock_container.mock_bookorbit_client.get_cover_bytes.return_value = (
             b"bookorbit-cover", "image/jpeg",
@@ -1584,10 +1587,16 @@ class TestCoverProxyUserIsolation(unittest.TestCase):
             ebook_source="Storyteller", ebook_source_id="st-text-1",
             ebook_filename="bo-audio.epub", duration=100, user_id=self.reg.id,
         ))
+        self.svc.save_book(Book(
+            abs_id="reg-booklore-ebook", abs_title="Reg Grimmory Ebook",
+            ebook_source="Grimmory", ebook_source_id="bl-ebook-1",
+            ebook_filename="bl-ebook.cbz", duration=100, user_id=self.reg.id,
+        ))
         self.svc.link_user_book(admin.id, "admin-book")
         self.svc.link_user_book(self.reg.id, "reg-book")
         self.svc.link_user_book(self.reg.id, "reg-booklore-audio")
         self.svc.link_user_book(self.reg.id, "reg-bookorbit-audio")
+        self.svc.link_user_book(self.reg.id, "reg-booklore-ebook")
 
     def tearDown(self):
         import src.db.migration_utils
@@ -1631,6 +1640,25 @@ class TestCoverProxyUserIsolation(unittest.TestCase):
         resp = self.client.get('/api/booklore/audiobook-cover/bl-audio-1')
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.data, b"booklore-cover")
+
+    def test_regular_user_can_proxy_owned_booklore_ebook_cover(self):
+        self._login("reg", "pw")
+        resp = self.client.get('/api/booklore/book-cover/bl-ebook-1')
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, b"book-cover")
+        self.assertEqual(resp.content_type, "image/webp")
+
+    def test_booklore_ebook_cover_missing_is_not_found(self):
+        self.mock_container.mock_booklore_client.get_book_cover_bytes.return_value = (None, None)
+        self._login("reg", "pw")
+        resp = self.client.get('/api/booklore/book-cover/bl-ebook-1')
+        self.assertEqual(resp.status_code, 404)
+
+    def test_booklore_ebook_cover_upstream_error_is_safe(self):
+        self.mock_container.mock_booklore_client.get_book_cover_bytes.side_effect = RuntimeError("down")
+        self._login("reg", "pw")
+        resp = self.client.get('/api/booklore/book-cover/bl-ebook-1')
+        self.assertEqual(resp.status_code, 500)
 
     def test_regular_user_can_proxy_owned_bookorbit_audio_with_other_ebook_source(self):
         """BookOrbit audio ids are not looked up through ebook source fields."""


### PR DESCRIPTION
## Summary

Fix Grimmory/BookLore ebook cover routing so mapped ebooks use Grimmory's ordinary book-cover endpoint instead of the audiobook-cover endpoint.

## Problem

For mapped Grimmory ebooks, BookBridge was building the browser cover URL through the audiobook-cover proxy. That is the wrong semantic for ordinary ebooks and caused missing cover art for CBZ/CBX books; the same routing could affect EPUB ebooks as well.

Grimmory's ordinary book cover is served from:

```text
GET /api/v1/media/book/{bookId}/cover
```

while audiobook cover handling is a separate path.

## Fix

- add a dedicated ordinary Grimmory book-cover fetch path;
- route `ebook_source` / `ebook_source_id` through the ordinary book-cover proxy;
- preserve existing audiobook-cover behavior for `audio_source` mappings;
- keep auth server-side so browser-facing URLs do not expose Grimmory credentials;
- honor existing BookLore/Booklore/Grimmory source normalization.

## Validation

The branch adds regression coverage for ebook cover routing and preserves audiobook behavior. Live validation with a Grimmory-hosted comic confirms the cover is rendered correctly after the change.

## Scope

This PR is intentionally limited to cover routing. It does not include CBZ progress handling, filename-rename resilience, KoSync sibling policy, deployment workflows, or database migrations.