### PR TITLE
[Fix] Add safe fixed-page CBZ progress sync

### DIFF
--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -3,12 +3,13 @@ import time
 import logging
 import threading
 from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
 from typing import Optional
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
-from pathlib import Path
 
 from src.utils.file_transfers import (
     IncompleteTransferError,
@@ -17,6 +18,7 @@ from src.utils.file_transfers import (
 )
 from src.utils.logging_utils import sanitize_log_data
 from src.sync_clients.sync_client_interface import LocatorResult
+from src.utils.fixed_page_progress import coerce_page, is_cbz_filename
 from src.utils.user_config import resolve_setting
 
 logger = logging.getLogger(__name__)
@@ -30,6 +32,14 @@ MAX_DETAIL_FETCHES_PER_SEARCH = 20
 # Safety bound on paginated scans so a server that never reports the last page
 # (or ignores the size param) can't loop forever. 10000 pages * 200 = 2M books.
 SCAN_MAX_PAGES = int(os.getenv("BOOKLORE_SCAN_MAX_PAGES", "10000"))
+
+
+class ProgressWriteOutcome(Enum):
+    """Non-boolean progress outcomes that callers must handle explicitly."""
+
+    SKIPPED = "skipped"
+
+
 # Concurrency for the detail-fetch fan-out during a full library refresh. The
 # session's connection pool is sized from this (see __init__) — urllib3's
 # default pool of 10 is exactly this worker count, which leaves no headroom and
@@ -1962,20 +1972,30 @@ class BookloreClient:
         return self._get_progress_by_book_id(book['id'])
 
     def get_progress_rich(self, ebook_filename):
-        """Progress plus Grimmory's own metadata for a filename, or None.
+        """Progress plus Grimmory's own metadata for a filename, or ``None``.
 
-        Returns ``{pct, cfi, href, last_read_time, status, content_source_pct}``
-        — lastReadTime is Grimmory's ISO timestamp of the last position change
-        and readStatus its reading status (verified live 2026-07-02). EPUB books
-        carry cfi/href from epubProgress; PDF/CBX fall back to percentage-only.
+        Returns percentage, locator fields, page data, lastReadTime and readStatus.
+        EPUB carries CFI/href, while CBX exposes its merged legacy/file page. For
+        EPUB/PDF, an absent progress row retains upstream's 0% semantics; CBX also
+        reports whether its percentage was actually present so a concrete page is
+        not mistaken for a reset.
         """
         book = self.find_book_by_filename(ebook_filename)
         if not book:
             return None
-        response = self._make_request("GET", f"/api/v1/books/{book['id']}")
+        return self.get_progress_rich_by_book_id(book['id'])
+
+    def get_progress_rich_by_book_id(self, book_id):
+        """Return rich progress without resolving or refreshing by filename.
+
+        For CBX, ``pct`` remains ``None`` when Grimmory omitted the percentage and
+        ``page`` is returned independently. EPUB/PDF preserve their established
+        absent-progress value of 0%.
+        """
+        response = self._make_request("GET", f"/api/v1/books/{book_id}")
         if not response or response.status_code != 200:
             return None
-        data = self._parse_json_response(response, f"Grimmory rich progress for book {book['id']}")
+        data = self._parse_json_response(response, f"Grimmory rich progress for book {book_id}")
         if not isinstance(data, dict):
             return None
 
@@ -1986,11 +2006,52 @@ class BookloreClient:
         ).upper()
         progress_key = {'EPUB': 'epubProgress', 'PDF': 'pdfProgress', 'CBX': 'cbxProgress'}.get(book_type)
         progress = (data.get(progress_key) or {}) if progress_key else {}
+        percentage_present = 'percentage' in progress and progress.get('percentage') is not None
+        cbx_page = coerce_page(progress.get('page')) if book_type == 'CBX' else None
+        pct = self._to_progress_fraction(progress.get('percentage')) if percentage_present else 0.0
+        if book_type == 'CBX' and cbx_page is not None and not percentage_present:
+            # A page without a percentage is an incomplete/stale pair and must be
+            # canonicalized by the sync client. A completely untouched CBX book,
+            # however, keeps upstream's 0% state so it participates in catch-up.
+            pct = None
+        primary_file = data.get('primaryFile') or {}
+        explicit_file_progress = (
+            data.get('fileProgress')
+            or primary_file.get('fileProgress')
+            or primary_file.get('progress')
+            or {}
+        )
+        file_position = explicit_file_progress.get('positionData')
+        if file_position in (None, ""):
+            file_position = explicit_file_progress.get('page')
+        file_page = coerce_page(file_position)
+        file_pct_raw = explicit_file_progress.get(
+            'progressPercent', explicit_file_progress.get('percentage')
+        )
+        file_pct = self._to_progress_fraction(file_pct_raw) if file_pct_raw is not None else None
+        # Derive observability from the same selected value as file_page so an
+        # explicit null positionData cannot mask a populated page fallback.
+        file_page_observable = file_position not in (None, "")
+        # Current Grimmory folds primary-file progress back into cbxProgress on
+        # GET. When it does not expose the file row separately, this merged value
+        # is the best available file-authoritative read-back.
+        if book_type == 'CBX' and primary_file.get('id') is not None and not explicit_file_progress:
+            file_page = coerce_page(progress.get('page'))
+            file_pct = pct
+            file_page_observable = file_page is not None
 
         return {
-            "pct": self._to_progress_fraction(progress.get('percentage', 0)),
+            "pct": pct,
+            "percentage_present": percentage_present,
             "cfi": progress.get('cfi') if book_type == 'EPUB' else None,
             "href": progress.get('href') if book_type == 'EPUB' else None,
+            "page": cbx_page,
+            "cbx_page": cbx_page,
+            "file_page": file_page if book_type == 'CBX' else None,
+            "file_pct": file_pct if book_type == 'CBX' else None,
+            "file_page_observable": file_page_observable if book_type == 'CBX' else False,
+            "book_file_id": primary_file.get('id'),
+            "book_type": book_type,
             "last_read_time": data.get('lastReadTime'),
             "status": data.get('readStatus'),
             "content_source_pct": progress.get('contentSourceProgressPercent'),
@@ -2238,6 +2299,26 @@ class BookloreClient:
         logger.error(f"❌ Grimmory audiobook update failed: {last_status}")
         return False
 
+    def _cache_verified_cbx_progress(self, book_id, verified: Optional[dict]) -> None:
+        """Mirror only values actually observed during CBX read-back."""
+        with self._cache_lock:
+            cached = self._book_id_cache.get(book_id)
+            if not cached:
+                return
+            if not isinstance(verified, dict):
+                cached.pop('cbxProgress', None)
+                return
+            page = coerce_page(verified.get('page'))
+            pct = verified.get('pct')
+            if page is None and pct is None:
+                cached.pop('cbxProgress', None)
+                return
+            progress = cached.setdefault('cbxProgress', {})
+            if page is not None:
+                progress['page'] = page
+            if pct is not None:
+                progress['percentage'] = float(pct) * 100.0
+
     def update_progress(self, ebook_filename, percentage, rich_locator: Optional[LocatorResult] = None):
         book = self.find_book_by_filename(ebook_filename)
         if not book:
@@ -2258,11 +2339,59 @@ class BookloreClient:
         clear_reset = book_type == 'EPUB' and percentage <= 0
         cfi = rich_locator.cfi if rich_locator and rich_locator.cfi else None
         href = rich_locator.href if rich_locator and rich_locator.href else None
+        fixed_cbz = book_type == 'CBX' and is_cbz_filename(ebook_filename)
+        cbx_page = coerce_page(getattr(rich_locator, 'page', None)) if rich_locator and fixed_cbz else None
+        if fixed_cbz:
+            if percentage <= 0:
+                percentage = 0.0
+                pct_display = 0.0
+                cbx_page = 1
+            elif cbx_page is None:
+                logger.warning(
+                    "Grimmory: refusing non-zero CBZ write without a reliable page for '%s'",
+                    safe_filename,
+                )
+                return False
         primary_file = book.get('primaryFile') or {}
         book_file_id = primary_file.get('id')
+        pre_write_cbx = self.get_progress_rich_by_book_id(book_id) if fixed_cbz else None
+        pre_write_page = (
+            coerce_page(pre_write_cbx.get('page'))
+            if isinstance(pre_write_cbx, dict)
+            else None
+        )
 
         payload_variants = []
-        if book_type in ('EPUB', 'PDF', 'CBX') and book_file_id is not None:
+        if fixed_cbz:
+            cbx_payload = {
+                "bookId": book_id,
+                "cbxProgress": {
+                    "page": cbx_page,
+                    "percentage": pct_display,
+                },
+            }
+            if book_file_id is not None:
+                cbx_payload["fileProgress"] = {
+                    "bookFileId": self._to_optional_int(book_file_id) or book_file_id,
+                    "positionData": str(cbx_page),
+                    "progressPercent": pct_display,
+                }
+                payload_variants.append(("cbxProgress+fileProgress", cbx_payload))
+                payload_variants.append(("fileProgress", {
+                    "bookId": book_id,
+                    "fileProgress": dict(cbx_payload["fileProgress"]),
+                }))
+                payload_variants.append(("cbxProgress", {
+                    "bookId": book_id,
+                    "cbxProgress": dict(cbx_payload["cbxProgress"]),
+                }))
+            else:
+                logger.warning(
+                    "Grimmory: primaryFile.id missing for '%s'; writing legacy CBX progress only",
+                    safe_filename,
+                )
+                payload_variants.append(("cbxProgress", cbx_payload))
+        elif book_type in ('EPUB', 'PDF', 'CBX') and book_file_id is not None:
             file_progress = {
                 "bookFileId": self._to_optional_int(book_file_id) or book_file_id,
                 "progressPercent": pct_display,
@@ -2301,7 +2430,11 @@ class BookloreClient:
             elif book_type == 'PDF':
                 payload_variants = [("standard", {"bookId": book_id, "pdfProgress": {"page": 1, "percentage": pct_display}})]
             elif book_type == 'CBX':
-                payload_variants = [("standard", {"bookId": book_id, "cbxProgress": {"page": 1, "percentage": pct_display}})]
+                logger.warning(
+                    "Grimmory: skipping percentage-only CBX write without primaryFile.id for '%s'",
+                    safe_filename,
+                )
+                return ProgressWriteOutcome.SKIPPED
             else:
                 logger.warning(f"Grimmory: Unknown book type {book_type} for '{safe_filename}'")
                 return False
@@ -2383,6 +2516,115 @@ class BookloreClient:
                         last_status = f"verify_mismatch:{verified_pct * 100:.2f}%"
                         continue
 
+            if fixed_cbz:
+                verified = None
+                for verify_attempt in range(2):
+                    if verify_attempt:
+                        time.sleep(0.1)
+                    verified = self.get_progress_rich_by_book_id(book_id)
+                    if not isinstance(verified, dict):
+                        continue
+                    observed_cbx = coerce_page(verified.get('cbx_page', verified.get('page')))
+                    observed_file = (
+                        coerce_page(verified.get('file_page'))
+                        if 'file_page' in verified
+                        else coerce_page(verified.get('page'))
+                    )
+                    file_page_observable = bool(
+                        verified.get(
+                            'file_page_observable',
+                            observed_file is not None,
+                        )
+                    )
+                    representations_match = observed_cbx == cbx_page and (
+                        book_file_id is None
+                        or not file_page_observable
+                        or observed_file == cbx_page
+                    )
+                    if representations_match:
+                        break
+                verified_page = coerce_page(verified.get('page')) if isinstance(verified, dict) else None
+                verified_cbx_page = (
+                    coerce_page(verified.get('cbx_page', verified.get('page')))
+                    if isinstance(verified, dict)
+                    else None
+                )
+                verified_file_page = (
+                    (
+                        coerce_page(verified.get('file_page'))
+                        if 'file_page' in verified
+                        else verified_page
+                    )
+                    if isinstance(verified, dict)
+                    else None
+                )
+                verified_pct = verified.get('pct') if isinstance(verified, dict) else None
+                verified_file_observable = bool(
+                    verified.get(
+                        'file_page_observable',
+                        verified_file_page is not None,
+                    )
+                ) if isinstance(verified, dict) else False
+                fully_verified = verified_cbx_page == cbx_page and (
+                    book_file_id is None
+                    or not verified_file_observable
+                    or verified_file_page == cbx_page
+                )
+                observed_pages = {
+                    page for page in (verified_page, verified_cbx_page, verified_file_page)
+                    if page is not None
+                }
+                remote_moved = pre_write_page is not None and any(
+                    page != cbx_page and page != pre_write_page
+                    for page in observed_pages
+                )
+                if remote_moved:
+                    logger.info(
+                        "Grimmory CBZ reader moved during verification for %s "
+                        "(attempted=%s observed=%s); preserving remote state",
+                        safe_filename, cbx_page, sorted(observed_pages),
+                    )
+                    self._cache_verified_cbx_progress(book_id, verified)
+                    return True
+                if fully_verified:
+                    if verified_pct is not None and abs(float(verified_pct) - float(percentage)) > 0.005:
+                        logger.info(
+                            "Grimmory CBZ page verified for %s; reported percentage differs "
+                            "(expected=%.2f%% observed=%.2f%% page=%s)",
+                            safe_filename, pct_display, float(verified_pct) * 100.0, cbx_page,
+                        )
+                    if book_file_id is not None and not verified_file_observable:
+                        logger.info(
+                            "Grimmory CBX page verified for %s; primary-file page is not observable",
+                            safe_filename,
+                        )
+                    else:
+                        logger.debug(
+                            "Grimmory CBZ representations verified for %s: cbx_page=%s file_page=%s",
+                            safe_filename, verified_cbx_page, verified_file_page,
+                        )
+                    self._cache_verified_cbx_progress(book_id, verified)
+                else:
+                    logger.warning(
+                        "Grimmory CBZ representation not yet confirmed for %s "
+                        "(variant=%s expected=%s cbx_page=%s file_page=%s)",
+                        safe_filename, variant_name, cbx_page,
+                        verified_cbx_page, verified_file_page,
+                    )
+                    if variant_idx < len(payload_variants):
+                        last_status = f"verify_{variant_name}_stale"
+                        continue
+                    # The POST was applied, but read-back is stale or unavailable.
+                    # Keep the actually observed state (or invalidate it) so a
+                    # concurrent reader is never replaced locally by our attempt.
+                    self._cache_verified_cbx_progress(book_id, verified)
+                    return True
+                if variant_name != "cbxProgress+fileProgress":
+                    logger.info(
+                        "Grimmory CBZ progress fallback accepted for %s (variant=%s)",
+                        safe_filename, variant_name,
+                    )
+
             logger.info(f"Grimmory: {safe_filename} -> {pct_display:.1f}%")
 
             # Update cache in-place instead of full library refresh
@@ -2402,7 +2644,7 @@ class BookloreClient:
                             if not cached.get('pdfProgress'):
                                 cached['pdfProgress'] = {}
                             cached['pdfProgress']['percentage'] = pct_display
-                        elif book_type == 'CBX':
+                        elif book_type == 'CBX' and not fixed_cbz:
                             if not cached.get('cbxProgress'):
                                 cached['cbxProgress'] = {}
                             cached['cbxProgress']['percentage'] = pct_display
@@ -3159,4 +3401,3 @@ class BookloreClient:
             )
             return False
         return True
-

--- a/src/sync_clients/booklore_sync_client.py
+++ b/src/sync_clients/booklore_sync_client.py
@@ -2,11 +2,25 @@ import os
 from typing import Optional
 import logging
 
-from src.api.booklore_client import BookloreClient
+from src.api.booklore_client import BookloreClient, ProgressWriteOutcome
 from src.db.models import Book, State
 from src.utils.ebook_utils import EbookParser
+from src.utils.fixed_page_progress import (
+    coerce_page,
+    count_cbz_pages,
+    estimate_cbz_page,
+    is_cbz_book,
+    page_from_persisted_state,
+    percentage_from_cbz_page,
+)
 from src.utils.progress_metadata import parse_service_timestamp
-from src.sync_clients.sync_client_interface import SyncClient, SyncResult, UpdateProgressRequest, ServiceState
+from src.sync_clients.sync_client_interface import (
+    LocatorResult,
+    SyncClient,
+    SyncResult,
+    UpdateProgressRequest,
+    ServiceState,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +40,16 @@ class BookloreSyncClient(SyncClient):
         """Grimmory participates in both audiobook and ebook sync modes."""
         return {'audiobook', 'ebook'}
 
+    def supports_fixed_page_progress(self) -> bool:
+        """Grimmory exposes a native page position for CBZ books."""
+        return True
+
     @staticmethod
     def _resolve_epub_filename(book: Book) -> Optional[str]:
         return getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None)
+
+    def _is_cbz_book(self, book: Book) -> bool:
+        return is_cbz_book(book)
 
     def supports_book(self, book: Book) -> bool:
         epub = self._resolve_epub_filename(book)
@@ -65,6 +86,45 @@ class BookloreSyncClient(SyncClient):
         else:
             bl_pct, bl_cfi = self.booklore_client.get_progress(epub)
 
+        if self._is_cbz_book(book) and rich is not None:
+            page = coerce_page(rich.get("page"))
+            if rich.get("page") not in (None, "") and page is None:
+                logger.warning(
+                    "Ignoring invalid Grimmory CBZ page %r for '%s'",
+                    rich.get("page"), epub,
+                )
+                return None
+            page_count = count_cbz_pages(self.ebook_parser, epub)
+            if page is not None and page_count is None:
+                logger.warning(
+                    "Grimmory CBZ page %s for '%s' cannot be canonicalized because page count is unavailable; ignoring its percentage",
+                    page, epub,
+                )
+                return None
+            canonical_pct = percentage_from_cbz_page(
+                self.ebook_parser, epub, page, page_count
+            )
+            if page is not None and canonical_pct is None:
+                logger.warning(
+                    "Ignoring out-of-range Grimmory CBZ page %s (page_count=%s) for '%s'",
+                    page, page_count, epub,
+                )
+                return None
+            percentage_present = rich.get("percentage_present", bl_pct is not None)
+            explicit_reset = (
+                percentage_present
+                and bl_pct is not None
+                and float(bl_pct) <= 0.0
+                and page == 1
+            )
+            if canonical_pct is not None and not explicit_reset:
+                if bl_pct is not None and abs(float(bl_pct) - canonical_pct) > 0.005:
+                    logger.warning(
+                        "Grimmory CBZ progress mismatch for '%s': reported=%.2f%%, page=%s -> canonical=%.2f%%; using page-derived progress",
+                        epub, float(bl_pct) * 100.0, page, canonical_pct * 100.0,
+                    )
+                bl_pct = canonical_pct
+                rich["page"] = page
         if bl_pct is None:
             logger.debug("Grimmory percentage is None - returning no service state")
             return None
@@ -78,6 +138,9 @@ class BookloreSyncClient(SyncClient):
         if rich is not None:
             if rich.get("href"):
                 current["href"] = rich["href"]
+            if rich.get("page") is not None:
+                current["page"] = rich["page"]
+                current["_previous_page"] = page_from_persisted_state(prev_state)
             service_updated_at = parse_service_timestamp(rich.get("last_read_time"))
             if service_updated_at is not None:
                 current["service_updated_at"] = service_updated_at
@@ -95,6 +158,10 @@ class BookloreSyncClient(SyncClient):
         )
 
     def get_text_from_current_state(self, book: Book, state: ServiceState) -> Optional[str]:
+        # The manager builds a first-class page locator directly from state.
+        if self._is_cbz_book(book):
+            return None
+
         bl_pct = state.current.get('pct')
         bl_cfi = state.current.get('cfi')
         epub = self._resolve_epub_filename(book)
@@ -110,7 +177,65 @@ class BookloreSyncClient(SyncClient):
         # Prefer the original filename for updates too.
         epub = self._resolve_epub_filename(book)
         pct = request.locator_result.percentage
-        success = self.booklore_client.update_progress(epub, pct, request.locator_result)
+        locator = request.locator_result
+
+        if self._is_cbz_book(book):
+            page_count = count_cbz_pages(self.ebook_parser, epub)
+            page = coerce_page(getattr(locator, "page", None))
+            if page is not None and page_count is None:
+                logger.warning(
+                    "Skipping Grimmory CBZ update for '%s': page count unavailable",
+                    book.abs_title,
+                )
+                current = request.current_state.current if request.current_state else {}
+                return SyncResult(current.get("pct"), True, dict(current), skipped=True)
+            if page_count and page and page > page_count:
+                logger.warning(
+                    "Ignoring out-of-range Grimmory CBZ page %s (page_count=%s) for '%s'",
+                    page, page_count, book.abs_title,
+                )
+                page = None
+            if pct is not None and float(pct) <= 0.0:
+                page = 1
+                pct = 0.0
+            elif page is None:
+                page = estimate_cbz_page(self.ebook_parser, epub, pct, page_count)
+            if page is None:
+                logger.warning(
+                    "Skipping Grimmory CBZ update due to unresolvable page for '%s'",
+                    book.abs_title,
+                )
+                current = request.current_state.current if request.current_state else {"pct": pct}
+                return SyncResult(current.get("pct"), True, dict(current), skipped=True)
+
+            canonical_pct = percentage_from_cbz_page(
+                self.ebook_parser, epub, page, page_count
+            )
+            if canonical_pct is not None and (pct is None or float(pct) > 0.0):
+                if (
+                    pct is not None
+                    and float(pct) > 0.0
+                    and abs(float(pct) - canonical_pct) > 0.005
+                ):
+                    logger.warning(
+                        "Correcting outgoing Grimmory CBZ progress for '%s': requested=%.2f%%, page=%s -> canonical=%.2f%%",
+                        epub, float(pct) * 100.0, page, canonical_pct * 100.0,
+                    )
+                pct = canonical_pct
+            if pct is None:
+                logger.warning(
+                    "Skipping Grimmory CBZ update without a reliable percentage for '%s'",
+                    book.abs_title,
+                )
+                current = request.current_state.current if request.current_state else {"pct": None, "page": page}
+                return SyncResult(current.get("pct"), True, dict(current), skipped=True)
+            locator = LocatorResult(percentage=pct, page=page)
+
+        outcome = self.booklore_client.update_progress(epub, pct, locator)
+        if outcome is ProgressWriteOutcome.SKIPPED:
+            current = request.current_state.current if request.current_state else {"pct": pct}
+            return SyncResult(current.get("pct"), True, dict(current), skipped=True)
+        success = bool(outcome)
         if success:
             try:
                 from src.services.write_tracker import record_write
@@ -120,6 +245,8 @@ class BookloreSyncClient(SyncClient):
         updated_state = {
             'pct': pct
         }
-        if request.locator_result and request.locator_result.cfi:
-            updated_state['cfi'] = request.locator_result.cfi
+        if self._is_cbz_book(book) and locator and locator.page is not None:
+            updated_state['page'] = locator.page
+        elif locator and locator.cfi:
+            updated_state['cfi'] = locator.cfi
         return SyncResult(pct, success, updated_state)

--- a/src/sync_clients/kavita_sync_client.py
+++ b/src/sync_clients/kavita_sync_client.py
@@ -10,6 +10,7 @@ from src.sync_clients.sync_client_interface import (
     SyncResult,
     UpdateProgressRequest,
 )
+from src.utils.fixed_page_progress import is_cbz_book
 from src.utils.progress_metadata import parse_service_timestamp
 
 logger = logging.getLogger(__name__)
@@ -21,6 +22,10 @@ class KavitaSyncClient(KoSyncSyncClient):
     def __init__(self, kavita_kosync_client, ebook_parser):
         super().__init__(kavita_kosync_client, ebook_parser)
         self._locator_pct_cache: dict[tuple[str, str], float] = {}
+
+    def supports_fixed_page_progress(self) -> bool:
+        """Kavita's KoSync-compatible transport does not use KOReader page mode."""
+        return False
 
     def supports_book(self, book: Book) -> bool:
         source = str(getattr(book, "ebook_source", "") or "").strip().lower()
@@ -77,7 +82,8 @@ class KavitaSyncClient(KoSyncSyncClient):
         remote_pct, xpath, metadata = self.kosync_client.get_progress_with_metadata(
             book.kosync_doc_id
         )
-        percentage = self._percentage_from_xpath(book, xpath)
+        fixed_page_file = is_cbz_book(book)
+        percentage = None if fixed_page_file else self._percentage_from_xpath(book, xpath)
         if percentage is None:
             try:
                 percentage = float(remote_pct) if remote_pct is not None else None
@@ -92,7 +98,7 @@ class KavitaSyncClient(KoSyncSyncClient):
         # the last persisted percentage.
         if prev_state and xpath and prev_state.xpath == xpath:
             previous_pct = percentage
-        current = {"pct": percentage, "xpath": xpath}
+        current = {"pct": percentage, "xpath": None if fixed_page_file else xpath}
         if remote_pct is not None:
             current["_remote_pct"] = remote_pct
         service_updated_at = parse_service_timestamp((metadata or {}).get("timestamp"))
@@ -109,6 +115,12 @@ class KavitaSyncClient(KoSyncSyncClient):
         )
 
     def update_progress(self, book: Book, request: UpdateProgressRequest) -> SyncResult:
+        if is_cbz_book(book):
+            # Kavita inherits the KoSync transport adapter but does not implement
+            # KOReader's fixed-page protocol. Never manufacture an EPUB XPath for
+            # a CBZ; retain the fresh target state and perform no write.
+            current = request.current_state.current if request.current_state else {}
+            return SyncResult(current.get("pct"), True, dict(current), skipped=True)
         result = super().update_progress(book, request)
         if result.success:
             try:
@@ -118,3 +130,8 @@ class KavitaSyncClient(KoSyncSyncClient):
             except ImportError:
                 pass
         return result
+
+    def get_text_from_current_state(self, book: Book, state: ServiceState) -> Optional[str]:
+        if is_cbz_book(book):
+            return None
+        return super().get_text_from_current_state(book, state)

--- a/src/sync_clients/kosync_sync_client.py
+++ b/src/sync_clients/kosync_sync_client.py
@@ -1,8 +1,8 @@
 import os
+import time
 from typing import Optional
 import logging
 import re
-import time
 
 from bs4 import BeautifulSoup, Tag
 from lxml import html
@@ -10,6 +10,14 @@ from lxml import html
 from src.api.api_clients import KoSyncClient
 from src.db.models import Book, State
 from src.utils.ebook_utils import EbookParser
+from src.utils.fixed_page_progress import (
+    coerce_page,
+    count_cbz_pages,
+    estimate_cbz_page,
+    is_cbz_book,
+    page_from_persisted_state,
+    percentage_from_cbz_page,
+)
 from src.utils.config_loader import env_truthy
 from src.utils.kosync_canonical import (
     prewarm_xpath_order_cache,
@@ -45,6 +53,10 @@ class KoSyncSyncClient(SyncClient):
         """KoSync participates in both audiobook and ebook sync modes."""
         return {'audiobook', 'ebook'}
 
+    def supports_fixed_page_progress(self) -> bool:
+        """The real KoSync protocol represents paged documents by page number."""
+        return True
+
     def supports_book(self, book: Book) -> bool:
         """Exclude audiobook-only mappings and books with invalid doc IDs."""
         sync_mode = getattr(book, "sync_mode", "audiobook")
@@ -67,6 +79,51 @@ class KoSyncSyncClient(SyncClient):
                 ko_pct, ko_xpath = self.kosync_client.get_progress(ko_id)
         else:
             ko_pct, ko_xpath = self.kosync_client.get_progress(ko_id)
+        epub = getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None)
+        page_is_estimated = False
+        if self.supports_fixed_page_progress() and is_cbz_book(book):
+            page = coerce_page(ko_xpath)
+            page_count = count_cbz_pages(self.ebook_parser, epub)
+            if ko_xpath not in (None, "") and page is None:
+                logger.warning(
+                    "Ignoring invalid KoSync CBZ page %r for '%s'",
+                    ko_xpath, epub,
+                )
+                return None
+            if page is not None and page_count is None:
+                logger.warning(
+                    "KoSync CBZ page %s for '%s' cannot be canonicalized because page count is unavailable; ignoring its percentage",
+                    page, epub,
+                )
+                return None
+            if page is None and ko_pct is not None and page_count is not None:
+                page = estimate_cbz_page(
+                    self.ebook_parser,
+                    epub,
+                    ko_pct,
+                    page_count,
+                    provenance="kosync",
+                )
+                ko_xpath = str(page) if page is not None else None
+                page_is_estimated = page is not None
+            canonical_pct = percentage_from_cbz_page(
+                self.ebook_parser, epub, page, page_count
+            )
+            if page is not None and canonical_pct is None:
+                logger.warning(
+                    "Ignoring out-of-range KoSync CBZ page %s (page_count=%s) for '%s'",
+                    page, page_count, epub,
+                )
+                return None
+            if canonical_pct is not None and (
+                ko_pct is None or float(ko_pct) > 0.0 or page > 1
+            ):
+                if ko_pct is not None and abs(float(ko_pct) - canonical_pct) > 0.005:
+                    logger.warning(
+                        "KoSync CBZ progress mismatch for '%s': reported=%.2f%%, page=%s -> canonical=%.2f%%; using page-derived progress",
+                        epub, float(ko_pct) * 100.0, page, canonical_pct * 100.0,
+                    )
+                ko_pct = canonical_pct
         book_label = f"'{title_snip}' " if title_snip else ""
         if ko_pct is None:
             if ko_xpath is None:
@@ -83,6 +140,11 @@ class KoSyncSyncClient(SyncClient):
         delta = abs(ko_pct - prev_kosync_pct)
 
         current = {"pct": ko_pct, "xpath": ko_xpath}
+        if self.supports_fixed_page_progress() and is_cbz_book(book):
+            current["page"] = coerce_page(ko_xpath)
+            current["_previous_page"] = page_from_persisted_state(prev_state)
+            if page_is_estimated:
+                current["_page_is_estimated"] = True
         rewind_at = get_kosync_approved_rewind_at(prev_state)
         if rewind_at is not None:
             current["kosync_approved_rewind_at"] = rewind_at
@@ -111,6 +173,8 @@ class KoSyncSyncClient(SyncClient):
         ko_xpath = state.current.get('xpath')
         ko_pct = state.current.get('pct')
         epub = getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None)
+        if self.supports_fixed_page_progress() and is_cbz_book(book):
+            return None
         if ko_xpath and epub:
             txt = self.ebook_parser.resolve_xpath(epub, ko_xpath)
             if txt:
@@ -311,6 +375,69 @@ class KoSyncSyncClient(SyncClient):
             if book
             else None
         )
+        # Keep the original cutoff through ordinary writes; their newer timestamps
+        # must not turn incidental locator drift into an intentional rewind (#434).
+        rewind_at = time.time() if request.allow_rewind else (
+            request.current_state.current.get("kosync_approved_rewind_at")
+            if request.current_state else None
+        )
+        if self.supports_fixed_page_progress() and is_cbz_book(book):
+            locator = request.locator_result
+            page_count = count_cbz_pages(self.ebook_parser, epub)
+            page = coerce_page(getattr(locator, "page", None))
+            if page is not None and page_count is None:
+                logger.warning(
+                    "Skipping KoSync CBZ update for '%s': page count unavailable",
+                    book.abs_title if book else "unknown",
+                )
+                current = request.current_state.current if request.current_state else {}
+                return SyncResult(current.get('pct'), True, dict(current), skipped=True)
+            if page_count and page and page > page_count:
+                logger.warning(
+                    "Ignoring out-of-range KoSync CBZ page %s (page_count=%s) for '%s'",
+                    page, page_count, book.abs_title if book else "unknown",
+                )
+                page = None
+            if page is None and pct is not None and pct > 0:
+                page = estimate_cbz_page(self.ebook_parser, epub, pct, page_count)
+
+            if pct is not None and pct <= 0:
+                pct = 0.0
+                page_progress = "1"
+            elif page is not None:
+                canonical_pct = percentage_from_cbz_page(
+                    self.ebook_parser, epub, page, page_count
+                )
+                if canonical_pct is not None:
+                    if pct is not None and abs(float(pct) - canonical_pct) > 0.005:
+                        logger.warning(
+                            "Correcting outgoing KoSync CBZ progress for '%s': requested=%.2f%%, page=%s -> canonical=%.2f%%",
+                            epub, float(pct) * 100.0, page, canonical_pct * 100.0,
+                        )
+                    pct = canonical_pct
+                page_progress = str(page)
+            else:
+                logger.warning(
+                    "Skipping KoSync CBZ update due to unresolvable page for '%s'",
+                    book.abs_title if book else "unknown",
+                )
+                current = request.current_state.current if request.current_state else {}
+                return SyncResult(current.get('pct'), True, dict(current), skipped=True)
+
+            if pct is None:
+                logger.warning(
+                    "Skipping KoSync CBZ update without a reliable percentage for '%s'",
+                    book.abs_title if book else "unknown",
+                )
+                current = request.current_state.current if request.current_state else {}
+                return SyncResult(current.get('pct'), True, dict(current), skipped=True)
+
+            success = self.kosync_client.update_progress(ko_id, pct, page_progress)
+            updated_state = {'pct': pct, 'xpath': page_progress}
+            if success and rewind_at is not None:
+                updated_state["kosync_approved_rewind_at"] = rewind_at
+            return SyncResult(pct, success, updated_state)
+
         # Always collapse generated KoSync positions to block-level XPointers.
         # Text-node and inline offsets can resolve poorly in KOReader/CREngine,
         # while paragraph-level anchors survive renderer differences better.
@@ -373,12 +500,6 @@ class KoSyncSyncClient(SyncClient):
                     exc_info=True,
                 )
 
-        # Keep the original cutoff through ordinary writes; their newer timestamps
-        # must not turn incidental locator drift into an intentional rewind (#434).
-        rewind_at = time.time() if request.allow_rewind else (
-            request.current_state.current.get("kosync_approved_rewind_at")
-            if request.current_state else None
-        )
         success = self.kosync_client.update_progress(ko_id, pct, safe_xpath)
         updated_state = {
             'pct': pct,

--- a/src/sync_clients/sync_client_interface.py
+++ b/src/sync_clients/sync_client_interface.py
@@ -37,6 +37,9 @@ class LocatorResult:
     css_selector: Optional[str] = None
     chapter_progress: Optional[float] = None
     fragments: Optional[list] = None
+    # Concrete 1-based position for fixed-page documents. Kept separate from
+    # CFI/fragment so page positions cannot leak as fake EPUB data.
+    page: Optional[int] = None
 
 @dataclass
 class UpdateProgressRequest:
@@ -129,6 +132,10 @@ class SyncClient:
         """Return True when this client is applicable to the provided book."""
         return True
 
+    def supports_fixed_page_progress(self) -> bool:
+        """Return whether this concrete client speaks page-based progress."""
+        return False
+
     def get_service_state(self, book: Book, prev_state: Optional[State], title_snip: str = "", bulk_context: dict = None) -> Optional[ServiceState]:
         """
         Args:
@@ -165,5 +172,6 @@ class SyncClient:
             perfect_ko_xpath=perfect_xpath,
             css_selector=locator_result.css_selector,
             chapter_progress=locator_result.chapter_progress,
-            fragments=locator_result.fragments
+            fragments=locator_result.fragments,
+            page=locator_result.page,
         )

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -55,6 +55,7 @@ from src.utils.transcription_cancel import (
 from src.utils.transcriber import TranscriptionCancelled
 from src.utils.logging_utils import sanitize_log_data, get_persistent_condition_logger
 from src.utils.progress_metadata import state_metadata_kwargs
+from src.utils.fixed_page_progress import coerce_page, is_cbz_book, is_cbz_filename
 
 # Service imports
 from src.services.alignment_service import AlignmentService, ingest_storyteller_transcripts
@@ -251,6 +252,8 @@ class SyncManager:
         if not hasattr(self, "_sync_cycle_ebook_cache"):
             self._sync_cycle_ebook_cache = {}
         if not ebook_filename:
+            return None, 0
+        if is_cbz_filename(ebook_filename):
             return None, 0
 
         cached = self._sync_cycle_ebook_cache.get(ebook_filename)
@@ -2854,8 +2857,14 @@ class SyncManager:
                 logger.info(
                     f"Ebook-only background prep: skipping Storyteller/SMIL/Whisper transcript generation for '{sanitize_log_data(abs_title)}'"
                 )
-                # Warm parser caches for subsequent locator-based sync cycles.
-                self.ebook_parser.extract_text_and_map(epub_path)
+                # Reflowable ebooks benefit from a warm text/locator cache. CBZ is
+                # fixed-page and must never be handed to ebooklib's EPUB parser.
+                if is_cbz_filename(epub_path.name):
+                    logger.info(
+                        f"Ebook-only background prep: skipping EPUB parser warmup for CBZ '{sanitize_log_data(epub_path.name)}'"
+                    )
+                else:
+                    self.ebook_parser.extract_text_and_map(epub_path)
                 update_progress(1.0, 3)
                 book.status = 'active'
                 persist_book()
@@ -3185,8 +3194,28 @@ class SyncManager:
         - API noise on long books (Grimmory's 20s rounding errors filtered)
         - Missing real progress on all books (30s+ changes do count)
         """
+        if self._has_fixed_page_delta(client_name, config[client_name], book):
+            return True
         delta_pct = self._state_percentage_delta(config[client_name])
         return self._is_significant_pct_delta(delta_pct, book)
+
+    def _has_fixed_page_delta(self, client_name, client_state, book) -> bool:
+        if not is_cbz_book(book):
+            return False
+        client = self.sync_clients.get(client_name)
+        try:
+            if not client or client.supports_fixed_page_progress() is not True:
+                return False
+        except (AttributeError, TypeError):
+            return False
+        current_page = coerce_page(client_state.current.get("page"))
+        previous_page = coerce_page(client_state.current.get("_previous_page"))
+        return (
+            not client_state.current.get("_page_is_estimated", False)
+            and current_page is not None
+            and previous_page is not None
+            and abs(current_page - previous_page) >= 1
+        )
 
     @staticmethod
     def _state_percentage_delta(client_state) -> float:
@@ -3970,6 +3999,9 @@ class SyncManager:
         is the bare percentage the device ignores (#364). Audio-time vetoes belong on
         the path where audio followers actually consume the locator.
         """
+        if is_cbz_filename(epub):
+            return None
+
         if not epub or str(epub).startswith("storyteller_") or locator.percentage is None:
             return None
         try:
@@ -4013,6 +4045,16 @@ class SyncManager:
                 f"'{abs_id}' '{title_snip}' CFI hydration failed: {exc}", exc_info=True
             )
             return None
+
+    @staticmethod
+    def _fixed_page_locator_from_state(client, state, percentage) -> LocatorResult:
+        """Build a first-class page locator only for clients that support it."""
+        try:
+            supports_pages = client.supports_fixed_page_progress() is True
+        except (AttributeError, TypeError):
+            supports_pages = False
+        page = coerce_page(state.current.get("page")) if supports_pages else None
+        return LocatorResult(percentage=percentage, page=page)
 
     @staticmethod
     def _sync_result_was_applied(result) -> bool:
@@ -4317,6 +4359,11 @@ class SyncManager:
         # Clear caches at start of cycle
         self._sync_cycle_ebook_cache.clear()
         self._sync_cycle_local_epub_cache.clear()
+        clear_fixed_page_cache = getattr(
+            getattr(self, "ebook_parser", None), "clear_fixed_page_count_cache", None
+        )
+        if callable(clear_fixed_page_cache):
+            clear_fixed_page_cache()
         self._storyteller_epub_ensure_attempted.clear()
         storyteller_client = self.sync_clients.get('Storyteller')
         if storyteller_client and hasattr(storyteller_client, 'storyteller_client'):
@@ -4515,7 +4562,18 @@ class SyncManager:
                 # Calculate char_delta = int(state.delta * total_chars)
                 # If char_delta >= self.delta_chars_thresh, log it and set significant_diff = True
                 char_delta_triggered = False  # Track if character delta triggered significance
-                if not significant_diff and hasattr(book, 'ebook_filename') and book.ebook_filename:
+                page_delta_triggered = any(
+                    self._has_fixed_page_delta(name, state, book)
+                    for name, state in config.items()
+                )
+                if page_delta_triggered:
+                    significant_diff = True
+                    logger.info(
+                        f"'{abs_id}' '{title_snip}' Significant fixed-page change detected"
+                    )
+                fixed_page_book = is_cbz_book(book)
+                if (not significant_diff and hasattr(book, 'ebook_filename') and book.ebook_filename
+                        and not fixed_page_book):
                     for client_name_key, client_state in config.items():
                          percentage_delta = self._state_percentage_delta(client_state)
                          if percentage_delta > 0:
@@ -4573,11 +4631,12 @@ class SyncManager:
                     for client_name in config.keys()
                 )
                 is_instant_target = bool(target_abs_id)
-                if (significant_diff and not any_significant_delta and not char_delta_triggered
+                if (significant_diff and not any_significant_delta and not char_delta_triggered and not page_delta_triggered
                         and not new_client_in_config and not is_instant_target):
                     logger.debug(f"'{abs_id}' '{title_snip}' Discrepancy exists ({max_progress*100:.1f}% vs {min_progress*100:.1f}%) but no recent client activity detected. Waiting for a new read event to determine true leader")
                     continue
-                if is_instant_target and significant_diff and not any_significant_delta and not char_delta_triggered and not new_client_in_config:
+                if (is_instant_target and significant_diff and not any_significant_delta
+                        and not char_delta_triggered and not page_delta_triggered and not new_client_in_config):
                     logger.info(f"'{abs_id}' '{title_snip}' Instant-sync target: resolving discrepancy ({max_progress*100:.1f}% vs {min_progress*100:.1f}%) — the triggering read already wrote State (delta=0)")
 
                 if significant_diff:
@@ -4642,7 +4701,12 @@ class SyncManager:
                 audio_only_mode = getattr(book, "sync_mode", "audiobook") == "audiobook_only"
 
                 primary_audio_client = self._get_primary_audio_client_name(book)
-                if leader == primary_audio_client:
+                if fixed_page_book:
+                    locator = self._fixed_page_locator_from_state(
+                        leader_client, leader_state, leader_pct
+                    )
+                    locator_source = "fixed_page"
+                elif leader == primary_audio_client:
                     abs_timestamp = leader_state.current.get('ts')
                     locator, txt = self._resolve_alignment_locator_from_abs_timestamp(book, abs_timestamp)
                     if locator:
@@ -4704,14 +4768,15 @@ class SyncManager:
                     logger.warning(f"⚠️ '{abs_id}' '{title_snip}' Could not resolve locator from text for leader '{leader}', falling back to percentage of leader")
                     locator = LocatorResult(percentage=leader_pct)
                     locator_source = "percent_fallback"
-                if txt is None:
+                if txt is None and not fixed_page_book:
                     txt = ""
 
                 # Locator-driven clients need a real position, not a bare percentage
                 # (see _hydrate_cfi_locator and #364). Resolve one once per cycle and
                 # hand it to whichever of them are in play.
                 hydrated_locator = None
-                if not locator.cfi and any(name in config for name in _CFI_DEPENDENT_CLIENTS):
+                if (not fixed_page_book and not locator.cfi
+                        and any(name in config for name in _CFI_DEPENDENT_CLIENTS)):
                     hydrated_locator = self._hydrate_cfi_locator(
                         locator, epub, abs_id, title_snip, leader, leader_pct, leader_formatter
                     )
@@ -4922,8 +4987,6 @@ class SyncManager:
 
                 # Save leader state
                 leader_state_data = leader_state.current
-                if leader == "KoSync" and leader_state_data.get("_approved_rewind"):
-                    leader_state_data["kosync_approved_rewind_at"] = current_time
 
                 leader_state_model = State(
                     abs_id=book.abs_id,

--- a/src/utils/ebook_utils.py
+++ b/src/utils/ebook_utils.py
@@ -103,6 +103,10 @@ class EbookParser:
         self._path_cache: OrderedDict[str, Path] = OrderedDict()
         self._path_cache_max = max(0, int(os.getenv("EBOOK_PATH_CACHE_SIZE", "100")))
         self._path_cache_lock = threading.Lock()
+        # Positive CBZ counts are cached only within one sync cycle. Failures are
+        # deliberately not cached so a transient NAS/ZIP error can recover.
+        self._fixed_page_count_cache: dict[str, int] = {}
+        self._fixed_page_count_cache_lock = threading.Lock()
 
         logger.info(
             f"✅ EbookParser initialized (cache={cache_size}, hash={self.hash_method}, "
@@ -1488,6 +1492,20 @@ class EbookParser:
             spine_index,
         )
         return None
+
+    def get_cached_fixed_page_count(self, filename: str) -> Optional[int]:
+        with self._fixed_page_count_cache_lock:
+            return self._fixed_page_count_cache.get(filename)
+
+    def cache_fixed_page_count(self, filename: str, page_count: int) -> None:
+        if page_count <= 0:
+            return
+        with self._fixed_page_count_cache_lock:
+            self._fixed_page_count_cache[filename] = page_count
+
+    def clear_fixed_page_count_cache(self) -> None:
+        with self._fixed_page_count_cache_lock:
+            self._fixed_page_count_cache.clear()
 
     def get_sentence_level_ko_xpath(self, filename, percentage) -> Optional[str]:
         """

--- a/src/utils/fixed_page_progress.py
+++ b/src/utils/fixed_page_progress.py
@@ -1,0 +1,150 @@
+"""Helpers for CBZ page positions shared by Grimmory and KoSync.
+
+KOReader stores ``progress`` as a page number for documents with ``has_pages``
+and sends ``current_page / page_count`` as the percentage. CBZ therefore uses
+the first-class ``LocatorResult.page`` field and never enters the EPUB text/CFI
+pipeline. A concrete in-range page is authoritative when a stored percentage
+disagrees.
+"""
+
+import json
+import math
+import zipfile
+from pathlib import Path
+from typing import Optional
+
+
+# KOReader's bundled MuPDF keeps the upstream CBZ extensions and adds WebP via
+# koreader-base/thirdparty/mupdf/webp-upstream-697749.patch. This metadata-only
+# policy models the entries KOReader treats as fixed pages; AVIF is not supported
+# by that patch and remains excluded.
+_KOREADER_CBZ_PAGE_EXTENSIONS = {
+    ".bmp", ".gif", ".hdp", ".j2k", ".jb2", ".jbig2", ".jp2", ".jpeg",
+    ".jpg", ".jpx", ".jxr", ".pam", ".pbm", ".pgm", ".pkm", ".png",
+    ".pnm", ".ppm", ".tif", ".tiff", ".wdp", ".webp",
+}
+
+
+def is_cbz_filename(filename: Optional[str]) -> bool:
+    """Return True when *filename* identifies a CBZ archive."""
+    if not filename:
+        return False
+    return Path(str(filename)).suffix.lower() == ".cbz"
+
+
+def is_cbz_book(book) -> bool:
+    """Return True when either persisted ebook filename identifies a CBZ."""
+    return any(
+        is_cbz_filename(getattr(book, attribute, None))
+        for attribute in ("original_ebook_filename", "ebook_filename")
+    )
+
+
+def coerce_page(value) -> Optional[int]:
+    """Convert a page value to a positive integer when possible."""
+    if value in (None, ""):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(numeric) or not numeric.is_integer():
+        return None
+    page = int(numeric)
+    return page if page > 0 else None
+
+
+def page_from_persisted_state(state) -> Optional[int]:
+    """Read a previously persisted fixed page from ``State.locator_json``."""
+    raw = getattr(state, "locator_json", None)
+    if not raw:
+        return None
+    try:
+        payload = json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return coerce_page(payload.get("page")) if isinstance(payload, dict) else None
+
+
+def count_cbz_pages(ebook_parser, filename: Optional[str]) -> Optional[int]:
+    """Return KOReader's CBZ page count without EPUB parsing.
+
+    Count the extension-only entries accepted by KOReader's bundled MuPDF.
+    Do not exclude cover, thumbnail, dot/AppleDouble, or nested files: MuPDF
+    counts those entries too. WebP is included by KOReader's MuPDF patch; AVIF
+    is not part of that supported set.
+    """
+    if not is_cbz_filename(filename) or ebook_parser is None:
+        return None
+
+    cache_key = str(filename)
+    cache_get = getattr(ebook_parser, "get_cached_fixed_page_count", None)
+    if callable(cache_get):
+        cached = cache_get(cache_key)
+        if isinstance(cached, int) and cached > 0:
+            return cached
+
+    try:
+        path = ebook_parser.resolve_book_path(filename)
+        if path is None:
+            page_count = None
+        else:
+            with zipfile.ZipFile(path) as archive:
+                page_count = sum(
+                    1
+                    for info in archive.infolist()
+                    if not info.is_dir()
+                    and Path(info.filename).suffix.lower() in _KOREADER_CBZ_PAGE_EXTENSIONS
+                )
+            page_count = page_count if page_count > 0 else None
+    except (OSError, TypeError, zipfile.BadZipFile, RuntimeError, ValueError):
+        page_count = None
+
+    if page_count is not None:
+        cache_put = getattr(ebook_parser, "cache_fixed_page_count", None)
+        if callable(cache_put):
+            cache_put(cache_key, page_count)
+    return page_count
+
+
+def percentage_from_cbz_page(
+    ebook_parser, filename: Optional[str], page, page_count: Optional[int] = None,
+) -> Optional[float]:
+    """Return canonical 0..1 progress for a 1-based CBZ page."""
+    page = coerce_page(page)
+    page_count = page_count or count_cbz_pages(ebook_parser, filename)
+    if page is None or not page_count or page > page_count:
+        return None
+    return page / float(page_count)
+
+
+def estimate_cbz_page(
+    ebook_parser,
+    filename: Optional[str],
+    percentage: float,
+    page_count: Optional[int] = None,
+    provenance: str = "generic",
+) -> Optional[int]:
+    """Estimate a displayed 1-based page with source-aware rounding.
+
+    KOReader sends ``floor((page / count) * 10000) / 10000``; its page owns the
+    interval ``((p - 1) / count, p / count]`` and therefore needs ``ceil``.
+    Generic services commonly round the percentage instead, where nearest-page
+    logic avoids a permanent +1 drift (for example 27.12% of 59 pages is page
+    16, not 17).
+    """
+    page_count = page_count or count_cbz_pages(ebook_parser, filename)
+    if not page_count:
+        return None
+    try:
+        pct = float(percentage)
+    except (TypeError, ValueError, OverflowError):
+        return None
+    if not math.isfinite(pct):
+        return None
+    pct = max(0.0, min(1.0, pct))
+    if str(provenance).lower() in {"koreader", "kosync"}:
+        page = int(math.ceil((pct * page_count) - 1e-12))
+    else:
+        page = int(math.floor((pct * page_count) + 0.5))
+    return max(1, min(page_count, page))

--- a/src/utils/progress_metadata.py
+++ b/src/utils/progress_metadata.py
@@ -20,6 +20,7 @@ This module is capture-only: nothing here influences leader selection.
 
 import json
 import logging
+import time
 from datetime import datetime, timezone
 from typing import Optional
 
@@ -125,6 +126,13 @@ def extract_locator_json(current: dict) -> Optional[str]:
         except (TypeError, ValueError):
             continue
         payload[key] = value
+
+    # KoSync's leader-state save path carries rewind intent as private metadata.
+    # Persist the cutoff before private keys are discarded so ordinary later
+    # writes cannot turn locator rounding into a newly approved rewind (#434).
+    if current.get("_approved_rewind") and current.get("xpath") is not None:
+        payload.setdefault("kosync_approved_rewind_at", time.time())
+
     if not payload:
         return None
     return json.dumps(payload, sort_keys=True)

--- a/tests/test_cbz_fixed_page_progress.py
+++ b/tests/test_cbz_fixed_page_progress.py
@@ -1,0 +1,1278 @@
+import threading
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.api.booklore_client import BookloreClient, ProgressWriteOutcome
+from src.api.bookorbit_client import BookOrbitClient
+from src.api.storyteller_api import StorytellerAPIClient
+from src.db.models import Book
+from src.sync_clients.abs_ebook_sync_client import ABSEbookSyncClient
+from src.sync_clients.booklore_sync_client import BookloreSyncClient
+from src.sync_clients.kosync_sync_client import KoSyncSyncClient
+from src.sync_clients.sync_client_interface import (
+    LocatorResult,
+    ServiceState,
+    SyncResult,
+    UpdateProgressRequest,
+)
+from src.sync_manager import SyncManager
+from src.utils.fixed_page_progress import (
+    coerce_page,
+    count_cbz_pages,
+    estimate_cbz_page,
+    percentage_from_cbz_page,
+)
+
+
+PAGE_COUNT = 59
+TEST_PAGE = 16
+
+
+@pytest.fixture
+def cbz_path(tmp_path):
+    path = tmp_path / "comic.cbz"
+    with zipfile.ZipFile(path, "w") as archive:
+        for page in range(1, PAGE_COUNT + 1):
+            archive.writestr(f"pages/{page:03}.jpg", b"image")
+        archive.writestr("ComicInfo.xml", b"<ComicInfo />")
+        archive.writestr("notes.txt", b"not a page")
+    return path
+
+
+@pytest.fixture
+def webp_cbz_path(tmp_path):
+    """Match the nested WebP-plus-ComicInfo layout KOReader reads as 58 pages."""
+    path = tmp_path / "Suske en Wiske - 002 - De Vliegende Aap.cbz"
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("ComicInfo.xml", b"<ComicInfo />")
+        for page in range(1, 59):
+            archive.writestr(
+                f"Comic Folder\\{page:03}.webp",
+                b"webp page",
+            )
+    return path
+
+
+class FixedPageParser:
+    def __init__(self, path: Path):
+        self.path = path
+        self._fixed_page_counts = {}
+        self.resolve_book_path = MagicMock(return_value=path)
+        self.extract_text_and_map = MagicMock(side_effect=AssertionError("CBZ must not use EPUB parsing"))
+        self.resolve_xpath = MagicMock(side_effect=AssertionError("CBZ must not resolve EPUB XPath"))
+        self.get_text_at_percentage = MagicMock(side_effect=AssertionError("CBZ must not resolve EPUB text"))
+        self.get_text_around_cfi = MagicMock(side_effect=AssertionError("CBZ must not hydrate EPUB CFI"))
+        self.find_text_location = MagicMock(side_effect=AssertionError("CBZ must not text-match EPUB content"))
+        self.get_sentence_level_ko_xpath = MagicMock(side_effect=AssertionError("CBZ must not generate KoSync XPath"))
+        self.resolve_xpath_to_index = MagicMock(side_effect=AssertionError("CBZ must not canonicalize EPUB XPath"))
+
+    def get_cached_fixed_page_count(self, filename):
+        return self._fixed_page_counts.get(filename)
+
+    def cache_fixed_page_count(self, filename, page_count):
+        self._fixed_page_counts[filename] = page_count
+
+    def clear_fixed_page_count_cache(self):
+        self._fixed_page_counts.clear()
+
+
+def cbz_book(path: Path):
+    return SimpleNamespace(
+        kosync_doc_id="a" * 32,
+        original_ebook_filename=str(path),
+        ebook_filename=None,
+        ebook_source="Grimmory",
+        sync_mode="ebook_only",
+        abs_id="book-1",
+        abs_title="Comic",
+    )
+
+
+def test_cbz_page_count_uses_image_entries_only(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    assert count_cbz_pages(parser, str(cbz_path)) == PAGE_COUNT
+    parser.extract_text_and_map.assert_not_called()
+
+
+def test_cbz_page_percentage_roundtrip(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    pct = percentage_from_cbz_page(parser, str(cbz_path), TEST_PAGE)
+    assert pct == pytest.approx(TEST_PAGE / PAGE_COUNT)
+    assert estimate_cbz_page(parser, str(cbz_path), pct) == TEST_PAGE
+
+
+def test_koreader_webp_cbz_counts_nested_pages_and_canonicalizes_progress(webp_cbz_path):
+    parser = FixedPageParser(webp_cbz_path)
+
+    assert count_cbz_pages(parser, str(webp_cbz_path)) == 58
+    assert percentage_from_cbz_page(parser, str(webp_cbz_path), 58) == 1.0
+    assert percentage_from_cbz_page(parser, str(webp_cbz_path), 6) == pytest.approx(6 / 58)
+
+
+def test_kosync_and_grimmory_read_webp_cbz_pages_as_service_state(webp_cbz_path):
+    parser = FixedPageParser(webp_cbz_path)
+    kosync = KoSyncSyncClient(
+        SimpleNamespace(
+            get_progress_with_metadata=lambda _doc_id: (0.75, "58", {}),
+            is_configured=lambda: True,
+        ),
+        parser,
+    )
+    grimmory = BookloreSyncClient(
+        SimpleNamespace(
+            get_progress_rich=lambda _filename: {
+                "pct": 0.0,
+                "cfi": None,
+                "page": 6,
+                "last_read_time": None,
+                "status": "READING",
+            },
+            is_configured=lambda: True,
+        ),
+        parser,
+    )
+
+    kosync_state = kosync.get_service_state(cbz_book(webp_cbz_path), None)
+    grimmory_state = grimmory.get_service_state(cbz_book(webp_cbz_path), None)
+
+    assert kosync_state is not None
+    assert kosync_state.current["page"] == 58
+    assert kosync_state.current["pct"] == 1.0
+    assert kosync_state.current["xpath"] == "58"
+    assert grimmory_state is not None
+    assert grimmory_state.current["page"] == 6
+    assert grimmory_state.current["pct"] == pytest.approx(6 / 58)
+
+
+def test_kosync_cbz_read_uses_concrete_page_as_authoritative(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    transport = SimpleNamespace(
+        get_progress_with_metadata=lambda _doc_id: (1.0, str(TEST_PAGE), {}),
+        is_configured=lambda: True,
+    )
+    client = KoSyncSyncClient(transport, parser)
+
+    state = client.get_service_state(cbz_book(cbz_path), None)
+
+    assert state.current["xpath"] == str(TEST_PAGE)
+    assert state.current["pct"] == pytest.approx(TEST_PAGE / PAGE_COUNT)
+    parser.extract_text_and_map.assert_not_called()
+    parser.resolve_xpath.assert_not_called()
+
+
+def test_kosync_cbz_write_uses_page_without_epub_xpath_or_cfi(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    transport = SimpleNamespace(
+        update_progress=MagicMock(return_value=True),
+        is_configured=lambda: True,
+    )
+    client = KoSyncSyncClient(transport, parser)
+    locator = LocatorResult(
+        percentage=1.0,
+        page=TEST_PAGE,
+    )
+
+    result = client.update_progress(cbz_book(cbz_path), UpdateProgressRequest(locator))
+
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    assert result.success is True
+    assert result.updated_state == {"pct": pytest.approx(expected_pct), "xpath": str(TEST_PAGE)}
+    transport.update_progress.assert_called_once_with("a" * 32, pytest.approx(expected_pct), str(TEST_PAGE))
+    parser.get_sentence_level_ko_xpath.assert_not_called()
+    parser.resolve_xpath_to_index.assert_not_called()
+    parser.extract_text_and_map.assert_not_called()
+
+
+def test_kosync_cbz_reset_preserves_zero_percent(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    transport = SimpleNamespace(
+        update_progress=MagicMock(return_value=True),
+        is_configured=lambda: True,
+    )
+    client = KoSyncSyncClient(transport, parser)
+    locator = LocatorResult(
+        percentage=0.0,
+        page=TEST_PAGE,
+    )
+
+    result = client.update_progress(cbz_book(cbz_path), UpdateProgressRequest(locator))
+
+    assert result.success is True
+    assert result.updated_state == {"pct": 0.0, "xpath": "1"}
+    transport.update_progress.assert_called_once_with("a" * 32, 0.0, "1")
+    parser.extract_text_and_map.assert_not_called()
+
+
+def test_grimmory_cbx_read_prefers_page_when_percentage_conflicts(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    grimmory = SimpleNamespace(
+        get_progress_rich=lambda _filename: {
+            "pct": 1.0,
+            "cfi": None,
+            "page": TEST_PAGE,
+            "last_read_time": None,
+            "status": "READING",
+        },
+        is_configured=lambda: True,
+    )
+    client = BookloreSyncClient(grimmory, parser)
+
+    state = client.get_service_state(cbz_book(cbz_path), None)
+
+    assert state.current["page"] == TEST_PAGE
+    assert state.current["pct"] == pytest.approx(TEST_PAGE / PAGE_COUNT)
+    parser.get_text_around_cfi.assert_not_called()
+    parser.get_text_at_percentage.assert_not_called()
+
+
+def make_cbx_api_client(readback):
+    book = {
+        "id": 42,
+        "fileName": "comic.cbz",
+        "bookType": "CBX",
+        "primaryFile": {
+            "id": 77,
+            "bookType": "CBX",
+            "fileName": "comic.cbz",
+        },
+    }
+    client = BookloreClient.__new__(BookloreClient)
+    client.find_book_by_filename = MagicMock(return_value=book)
+    client._fetch_and_cache_detail = MagicMock(return_value=None)
+    client._make_request = MagicMock(return_value=SimpleNamespace(status_code=204))
+    client.get_progress_rich_by_book_id = MagicMock(return_value=readback)
+    client._cache_lock = threading.RLock()
+    client._book_id_cache = {42: book}
+    client._epub_cfi_write_disabled_for_books = set()
+    return client
+
+
+def make_rich_progress_client(data):
+    response = SimpleNamespace(status_code=200, json=lambda: data, text="")
+    client = BookloreClient.__new__(BookloreClient)
+    client._make_request = MagicMock(return_value=response)
+    return client
+
+
+@pytest.mark.parametrize(
+    ("book_type", "progress_key"),
+    [("EPUB", "epubProgress"), ("PDF", "pdfProgress")],
+)
+def test_grimmory_non_cbx_missing_progress_preserves_zero_semantics(
+    book_type, progress_key
+):
+    client = make_rich_progress_client(
+        {"id": 42, "bookType": book_type, progress_key: None}
+    )
+
+    rich = client.get_progress_rich_by_book_id(42)
+
+    assert rich["pct"] == 0.0
+    assert rich["percentage_present"] is False
+
+
+def test_grimmory_unknown_book_type_preserves_safe_zero_semantics():
+    client = make_rich_progress_client({"id": 42, "bookType": "UNKNOWN"})
+
+    assert client.get_progress_rich_by_book_id(42)["pct"] == 0.0
+
+
+def test_untouched_grimmory_cbx_preserves_zero_percent_state():
+    client = make_rich_progress_client(
+        {
+            "id": 42,
+            "bookType": "CBX",
+            "cbxProgress": None,
+            "primaryFile": {"id": 77, "bookType": "CBX"},
+        }
+    )
+
+    rich = client.get_progress_rich_by_book_id(42)
+
+    assert rich["pct"] == 0.0
+    assert rich["page"] is None
+    assert rich["percentage_present"] is False
+
+
+def test_untouched_grimmory_cbz_produces_zero_percent_service_state(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    api = SimpleNamespace(
+        get_progress_rich=lambda _filename: {
+            "pct": 0.0,
+            "percentage_present": False,
+            "cfi": None,
+            "page": None,
+            "last_read_time": None,
+            "status": None,
+        },
+        is_configured=lambda: True,
+    )
+
+    state = BookloreSyncClient(api, parser).get_service_state(
+        cbz_book(cbz_path), None
+    )
+
+    assert state is not None
+    assert state.current["pct"] == 0.0
+    assert state.current.get("page") is None
+
+
+def test_grimmory_epub_missing_progress_produces_service_state():
+    api = SimpleNamespace(
+        get_progress_rich=lambda _filename: {
+            "pct": 0.0,
+            "percentage_present": False,
+            "cfi": None,
+            "page": None,
+            "last_read_time": None,
+            "status": None,
+        },
+        is_configured=lambda: True,
+    )
+    parser = MagicMock()
+    client = BookloreSyncClient(api, parser)
+    book = cbz_book(Path("book.epub"))
+    book.original_ebook_filename = "book.epub"
+
+    state = client.get_service_state(book, None)
+
+    assert state is not None
+    assert state.current["pct"] == 0.0
+
+
+def test_grimmory_cbx_write_sends_native_and_file_progress():
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    client = make_cbx_api_client({"pct": expected_pct, "page": TEST_PAGE})
+    locator = LocatorResult(percentage=expected_pct, page=TEST_PAGE)
+
+    with patch("src.api.booklore_client.time.sleep"):
+        assert client.update_progress("comic.cbz", expected_pct, locator) is True
+
+    payload = client._make_request.call_args.args[2]
+    assert payload["cbxProgress"] == {
+        "page": TEST_PAGE,
+        "percentage": pytest.approx(expected_pct * 100.0),
+    }
+    assert payload["fileProgress"] == {
+        "bookFileId": 77,
+        "positionData": str(TEST_PAGE),
+        "progressPercent": pytest.approx(expected_pct * 100.0),
+    }
+    assert client.get_progress_rich_by_book_id.call_count == 2
+
+
+def test_grimmory_cbx_reset_writes_page_one_and_zero_percent():
+    client = make_cbx_api_client({"pct": 0.0, "page": 1})
+    locator = LocatorResult(percentage=0.0)
+
+    with patch("src.api.booklore_client.time.sleep"):
+        assert client.update_progress("comic.cbz", 0.0, locator) is True
+
+    payload = client._make_request.call_args.args[2]
+    assert payload["cbxProgress"] == {"page": 1, "percentage": 0.0}
+    assert payload["fileProgress"] == {
+        "bookFileId": 77,
+        "positionData": "1",
+        "progressPercent": 0.0,
+    }
+
+
+def test_grimmory_sync_client_reset_stays_zero_percent(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    api = MagicMock()
+    api.update_progress.return_value = True
+    client = BookloreSyncClient(api, parser)
+
+    result = client.update_progress(
+        cbz_book(cbz_path),
+        UpdateProgressRequest(LocatorResult(percentage=0.0, page=1)),
+    )
+
+    assert result.success is True
+    assert result.updated_state == {"pct": 0.0, "page": 1}
+    written_locator = api.update_progress.call_args.args[2]
+    assert api.update_progress.call_args.args[1] == 0.0
+    assert written_locator.percentage == 0.0
+    assert written_locator.page == 1
+
+
+def test_grimmory_cbx_write_accepts_correct_page_with_percentage_mismatch():
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    client = make_cbx_api_client({"pct": 1.0, "page": TEST_PAGE})
+    locator = LocatorResult(percentage=expected_pct, page=TEST_PAGE)
+
+    with patch("src.api.booklore_client.time.sleep"):
+        assert client.update_progress("comic.cbz", expected_pct, locator) is True
+
+    assert client.get_progress_rich_by_book_id.call_count == 2
+
+
+def build_manager(tmp_path):
+    db = MagicMock()
+    db.get_books_by_status.return_value = []
+    return SyncManager(
+        abs_client=MagicMock(),
+        booklore_client=MagicMock(),
+        hardcover_client=MagicMock(),
+        transcriber=MagicMock(),
+        ebook_parser=MagicMock(),
+        database_service=db,
+        storyteller_client=MagicMock(),
+        sync_clients={},
+        alignment_service=None,
+        library_service=None,
+        migration_service=None,
+        epub_cache_dir=tmp_path / "epub_cache",
+        data_dir=tmp_path,
+        books_dir=tmp_path / "books",
+    )
+
+
+def cycle_client(*, fixed_pages=False, update_result=None):
+    client = MagicMock()
+    client.get_supported_sync_types.return_value = {"ebook"}
+    client.supports_book.return_value = True
+    client.can_be_leader.return_value = True
+    client.supports_fixed_page_progress.return_value = fixed_pages
+    client.get_text_from_current_state.return_value = "anchor text"
+    client.get_locator_from_text.side_effect = lambda _txt, _epub, pct: LocatorResult(
+        percentage=pct, cfi="epubcfi(/6/2)", match_index=40
+    )
+    client.update_progress.return_value = update_result or SyncResult(
+        0.4, True, {"pct": 0.4}
+    )
+    return client
+
+
+def cycle_state(pct, *, page=None, normalized_ts=None):
+    current = {"pct": pct}
+    if page is not None:
+        current["page"] = page
+    if normalized_ts is not None:
+        current["_normalized_ts"] = normalized_ts
+    return ServiceState(
+        current=current,
+        previous_pct=pct,
+        delta=0.0,
+        threshold=0.01,
+        is_configured=True,
+        display=("test", "{prev:.2%}->{curr:.2%}"),
+        value_formatter=lambda value: f"{value:.2%}",
+    )
+
+
+def configure_cycle(manager, book, config, previous_states):
+    manager.sync_delta_between_clients = 0.005
+    manager.delta_chars_thresh = 2000
+    manager.database_service.get_book.return_value = book
+    manager.database_service.get_states_for_book.return_value = previous_states
+    manager.database_service.save_state = MagicMock()
+    manager._filter_books_for_current_user = lambda books, _bulk: books
+    manager._promote_alignment_backed_book = MagicMock(return_value=False)
+    manager._fetch_states_parallel = MagicMock(return_value=config)
+    manager._normalize_for_cross_format_comparison = MagicMock(return_value=None)
+    manager._record_reading_movement = MagicMock()
+    manager._get_local_epub = lambda filename: Path(filename)
+
+
+def test_new_zero_percent_grimmory_state_catches_up_from_kosync(tmp_path):
+    manager = build_manager(tmp_path)
+    kosync = cycle_client()
+    grimmory = cycle_client()
+    manager.sync_clients = {"KoSync": kosync, "BookLore": grimmory}
+    book = SimpleNamespace(
+        abs_id="book-1",
+        abs_title="Initial Catch-up",
+        status="active",
+        sync_mode="ebook_only",
+        ebook_filename="book.epub",
+        original_ebook_filename="book.epub",
+        duration=None,
+        transcript_file=None,
+    )
+    config = {
+        "KoSync": cycle_state(0.4),
+        "BookLore": cycle_state(0.0),
+    }
+    previous = [
+        SimpleNamespace(
+            client_name="kosync",
+            last_updated=100,
+            percentage=0.4,
+            timestamp=None,
+            xpath=None,
+            cfi=None,
+        )
+    ]
+    configure_cycle(manager, book, config, previous)
+
+    manager._sync_cycle_internal(target_abs_id="book-1")
+
+    grimmory.update_progress.assert_called_once()
+    request = grimmory.update_progress.call_args.args[1]
+    assert request.locator_result.percentage == 0.4
+
+
+def test_real_cbz_clients_catch_up_untouched_grimmory_in_manager_cycle(
+    tmp_path, cbz_path
+):
+    manager = build_manager(tmp_path)
+    parser = FixedPageParser(cbz_path)
+    kosync_api = SimpleNamespace(
+        get_progress_with_metadata=lambda _doc_id: (
+            TEST_PAGE / PAGE_COUNT,
+            str(TEST_PAGE),
+            {},
+        ),
+        update_progress=MagicMock(return_value=True),
+        is_configured=lambda: True,
+    )
+    grimmory_api = SimpleNamespace(
+        get_progress_rich=lambda _filename: {
+            "pct": 0.0,
+            "percentage_present": False,
+            "cfi": None,
+            "page": None,
+            "last_read_time": None,
+            "status": None,
+        },
+        update_progress=MagicMock(return_value=True),
+        is_configured=lambda: True,
+    )
+    manager.ebook_parser = parser
+    manager.sync_clients = {
+        "KoSync": KoSyncSyncClient(kosync_api, parser),
+        "BookLore": BookloreSyncClient(grimmory_api, parser),
+    }
+    book = cbz_book(cbz_path)
+    book.status = "active"
+    book.duration = None
+    book.transcript_file = None
+    book.audio_source = None
+    manager.database_service.get_book.return_value = book
+    manager.database_service.get_states_for_book.return_value = [
+        SimpleNamespace(
+            client_name="kosync",
+            last_updated=100,
+            percentage=TEST_PAGE / PAGE_COUNT,
+            timestamp=None,
+            xpath=str(TEST_PAGE),
+            cfi=None,
+            locator_json=f'{{"page": {TEST_PAGE}}}',
+        )
+    ]
+    manager.database_service.save_state = MagicMock()
+    manager._filter_books_for_current_user = lambda books, _bulk: books
+    manager._promote_alignment_backed_book = MagicMock(return_value=False)
+    manager._normalize_for_cross_format_comparison = MagicMock(return_value=None)
+    manager._record_reading_movement = MagicMock()
+    manager._get_local_epub = MagicMock(return_value=cbz_path)
+
+    manager._sync_cycle_internal(target_abs_id="book-1")
+
+    grimmory_api.update_progress.assert_called_once()
+    filename, percentage, locator = grimmory_api.update_progress.call_args.args
+    assert filename == str(cbz_path)
+    assert percentage == pytest.approx(TEST_PAGE / PAGE_COUNT)
+    assert locator.page == TEST_PAGE
+
+
+def test_fixed_page_skip_is_persisted_by_manager_without_write_marker(tmp_path):
+    manager = build_manager(tmp_path)
+    kosync = cycle_client(fixed_pages=True)
+    skipped_state = {"pct": 0.0, "page": 1}
+    grimmory = cycle_client(
+        fixed_pages=True,
+        update_result=SyncResult(0.0, True, skipped_state, skipped=True),
+    )
+    manager.sync_clients = {"KoSync": kosync, "BookLore": grimmory}
+    book = SimpleNamespace(
+        abs_id="book-1",
+        abs_title="Skip Persistence",
+        status="active",
+        sync_mode="ebook_only",
+        ebook_filename="comic.cbz",
+        original_ebook_filename="comic.cbz",
+        duration=None,
+        transcript_file=None,
+    )
+    config = {
+        "KoSync": cycle_state(0.4, page=16),
+        "BookLore": cycle_state(0.0, page=1),
+    }
+    previous = [
+        SimpleNamespace(
+            client_name="kosync", last_updated=100, percentage=0.4,
+            timestamp=None, xpath="16", cfi=None, locator_json='{"page": 16}',
+        )
+    ]
+    configure_cycle(manager, book, config, previous)
+
+    with patch("src.services.write_tracker.record_write") as record_write:
+        manager._sync_cycle_internal(target_abs_id="book-1")
+
+    saved_followers = [
+        state for call in manager.database_service.save_state.call_args_list
+        for state in call.args
+        if state.client_name == "booklore"
+    ]
+    assert len(saved_followers) == 1
+    assert saved_followers[0].percentage == 0.0
+    assert saved_followers[0].locator_json == '{"page": 1}'
+    record_write.assert_not_called()
+    assert SyncManager._sync_result_was_applied(
+        grimmory.update_progress.return_value
+    ) is False
+
+
+def test_cbz_with_alignment_metadata_never_enters_locator_resolution(tmp_path):
+    manager = build_manager(tmp_path)
+    kosync = cycle_client(fixed_pages=True)
+    grimmory = cycle_client(fixed_pages=True)
+    manager.sync_clients = {"KoSync": kosync, "BookLore": grimmory}
+    book = SimpleNamespace(
+        abs_id="book-1",
+        abs_title="Comic with transcript",
+        status="active",
+        sync_mode="ebook_only",
+        ebook_filename="fallback.epub",
+        original_ebook_filename="comic.cbz",
+        duration=3600,
+        transcript_file="DB_MANAGED",
+    )
+    config = {
+        "KoSync": cycle_state(0.4, page=16, normalized_ts=1440),
+        "BookLore": cycle_state(0.0, page=1),
+    }
+    configure_cycle(manager, book, config, [])
+    manager._resolve_alignment_locator_from_abs_timestamp = MagicMock(
+        side_effect=AssertionError("CBZ must not use alignment locator resolution")
+    )
+    manager._resolve_storyteller_locator_from_abs_timestamp = MagicMock(
+        side_effect=AssertionError("CBZ must not use Storyteller locator resolution")
+    )
+    manager._get_local_epub = MagicMock(
+        side_effect=lambda filename: (
+            None if str(filename).endswith("comic.cbz") else Path(filename)
+        )
+    )
+
+    manager._sync_cycle_internal(target_abs_id="book-1")
+
+    manager._resolve_alignment_locator_from_abs_timestamp.assert_not_called()
+    manager._resolve_storyteller_locator_from_abs_timestamp.assert_not_called()
+    request = grimmory.update_progress.call_args.args[1]
+    assert request.locator_result.page == TEST_PAGE
+
+
+def test_sync_manager_never_parses_or_hydrates_cbz_as_epub(tmp_path):
+    manager = build_manager(tmp_path)
+    manager._get_local_epub = MagicMock(side_effect=AssertionError("CBZ must not be hydrated as EPUB"))
+    manager.ebook_parser.extract_text_and_map.side_effect = AssertionError("CBZ must not use EPUB parser")
+
+    assert manager._get_cached_ebook_text("comic.cbz") == (None, 0)
+    locator = LocatorResult(percentage=0.5)
+    assert manager._hydrate_cfi_locator(locator, "comic.cbz", "book-1", "Comic", "KoSync", 0.5, str) is None
+
+    manager._get_local_epub.assert_not_called()
+    manager.ebook_parser.extract_text_and_map.assert_not_called()
+
+
+def test_sync_manager_cbz_background_prep_skips_epub_warmup(tmp_path, cbz_path):
+    manager = build_manager(tmp_path)
+    library = MagicMock()
+    library.acquire_ebook.return_value = str(cbz_path)
+    manager.ebook_parser.extract_text_and_map.side_effect = AssertionError("CBZ must not use EPUB parser")
+    job = SimpleNamespace(retry_count=2, last_error="previous failure", progress=0.4)
+    manager.database_service.get_latest_job.return_value = job
+    book = Book(
+        abs_id="cbz-background-prep",
+        abs_title="Comic",
+        ebook_filename=cbz_path.name,
+        original_ebook_filename=cbz_path.name,
+        kosync_doc_id="a" * 32,
+        sync_mode="ebook_only",
+        status="processing",
+    )
+
+    manager._run_background_job(book, library_service=library)
+
+    library.acquire_ebook.assert_called_once_with(None, book)
+    manager.ebook_parser.extract_text_and_map.assert_not_called()
+    assert book.status == "active"
+    manager.database_service.update_book_if_exists.assert_called_once_with(book)
+    manager.database_service.save_job.assert_called_once_with(job)
+    assert job.progress == 1.0
+    assert job.last_error is None
+    assert job.retry_count == 0
+
+
+def test_grimmory_nonzero_cbz_write_without_page_is_rejected():
+    client = make_cbx_api_client({"pct": 0.7, "page": None})
+
+    assert client.update_progress("comic.cbz", 0.6949, LocatorResult(percentage=0.6949)) is False
+
+    client._make_request.assert_not_called()
+
+
+@pytest.mark.parametrize("suffix", [".cbr", ".cbt", ".cb7"])
+def test_non_cbz_cbx_formats_keep_percentage_only_file_progress(suffix):
+    client = make_cbx_api_client({"pct": 0.5, "page": 1})
+
+    assert client.update_progress(f"comic{suffix}", 0.5, LocatorResult(percentage=0.5)) is True
+
+    payload = client._make_request.call_args.args[2]
+    assert payload == {
+        "bookId": 42,
+        "fileProgress": {"bookFileId": 77, "progressPercent": 50.0},
+    }
+
+
+def test_kosync_page_only_read_derives_percentage(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    transport = SimpleNamespace(
+        get_progress_with_metadata=lambda _doc_id: (None, str(TEST_PAGE), {}),
+        is_configured=lambda: True,
+    )
+
+    state = KoSyncSyncClient(transport, parser).get_service_state(cbz_book(cbz_path), None)
+
+    assert state.current["page"] == TEST_PAGE
+    assert state.current["pct"] == pytest.approx(TEST_PAGE / PAGE_COUNT)
+
+
+@pytest.mark.parametrize("reported_pct", [None, 0.0])
+def test_grimmory_concrete_page_beats_missing_or_stale_zero(cbz_path, reported_pct):
+    parser = FixedPageParser(cbz_path)
+    grimmory = SimpleNamespace(
+        get_progress_rich=lambda _filename: {
+            "pct": reported_pct,
+            "percentage_present": reported_pct is not None,
+            "cfi": None,
+            "page": TEST_PAGE,
+            "last_read_time": None,
+            "status": "READING",
+        },
+        is_configured=lambda: True,
+    )
+
+    state = BookloreSyncClient(grimmory, parser).get_service_state(cbz_book(cbz_path), None)
+
+    assert state.current["page"] == TEST_PAGE
+    assert state.current["pct"] == pytest.approx(TEST_PAGE / PAGE_COUNT)
+
+
+def test_grimmory_applied_write_with_inconclusive_readback_succeeds():
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    client = make_cbx_api_client(None)
+
+    with patch("src.api.booklore_client.time.sleep"):
+        assert client.update_progress(
+            "comic.cbz", expected_pct, LocatorResult(percentage=expected_pct, page=TEST_PAGE)
+        ) is True
+
+    assert client.get_progress_rich_by_book_id.call_count == 7
+    assert client._make_request.call_count == 3
+
+
+def test_grimmory_sync_records_an_applied_cbz_write(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    api = MagicMock()
+    api.update_progress.return_value = True
+    client = BookloreSyncClient(api, parser)
+    pct = TEST_PAGE / PAGE_COUNT
+
+    with patch("src.services.write_tracker.record_write") as record_write:
+        result = client.update_progress(
+            cbz_book(cbz_path),
+            UpdateProgressRequest(LocatorResult(percentage=pct, page=TEST_PAGE)),
+        )
+
+    assert result.success is True
+    record_write.assert_called_once_with("BookLore", "book-1", pytest.approx(pct))
+
+
+def test_grimmory_cbz_without_primary_file_id_degrades_to_legacy_only():
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    client = make_cbx_api_client({"pct": expected_pct, "page": TEST_PAGE})
+    client.find_book_by_filename.return_value["primaryFile"].pop("id")
+
+    assert client.update_progress(
+        "comic.cbz", expected_pct, LocatorResult(percentage=expected_pct, page=TEST_PAGE)
+    ) is True
+
+    payload = client._make_request.call_args.args[2]
+    assert "fileProgress" not in payload
+    assert payload["cbxProgress"]["page"] == TEST_PAGE
+
+
+def test_grimmory_combined_payload_has_safe_file_progress_fallback():
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    client = make_cbx_api_client({"pct": expected_pct, "page": TEST_PAGE})
+    failed = SimpleNamespace(status_code=400, text="unsupported")
+    applied = SimpleNamespace(status_code=204, text="")
+    client._make_request.side_effect = [failed, applied]
+
+    assert client.update_progress(
+        "comic.cbz", expected_pct, LocatorResult(percentage=expected_pct, page=TEST_PAGE)
+    ) is True
+
+    payloads = [call.args[2] for call in client._make_request.call_args_list]
+    assert set(payloads[0]) == {"bookId", "cbxProgress", "fileProgress"}
+    assert set(payloads[1]) == {"bookId", "fileProgress"}
+    assert payloads[1]["fileProgress"]["positionData"] == str(TEST_PAGE)
+
+
+def test_grimmory_stale_file_progress_after_combined_post_uses_fallback():
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    before = {
+        "pct": 10 / PAGE_COUNT,
+        "page": 10,
+        "cbx_page": 10,
+        "file_page": 10,
+    }
+    stale_file = {
+        "pct": expected_pct,
+        "page": TEST_PAGE,
+        "cbx_page": TEST_PAGE,
+        "file_page": 10,
+    }
+    fully_applied = {
+        "pct": expected_pct,
+        "page": TEST_PAGE,
+        "cbx_page": TEST_PAGE,
+        "file_page": TEST_PAGE,
+    }
+    client = make_cbx_api_client(None)
+    client.get_progress_rich_by_book_id.side_effect = [
+        before,
+        stale_file,
+        stale_file,
+        fully_applied,
+    ]
+
+    with patch("src.api.booklore_client.time.sleep"):
+        assert client.update_progress(
+            "comic.cbz",
+            expected_pct,
+            LocatorResult(percentage=expected_pct, page=TEST_PAGE),
+        ) is True
+
+    assert client._make_request.call_count == 2
+    fallback = client._make_request.call_args_list[1].args[2]
+    assert set(fallback) == {"bookId", "fileProgress"}
+    assert fallback["fileProgress"]["positionData"] == str(TEST_PAGE)
+
+
+def test_grimmory_failed_prewrite_read_does_not_mask_non_applied_write():
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    unchanged = {
+        "pct": 10 / PAGE_COUNT,
+        "page": 10,
+        "cbx_page": 10,
+        "file_page": 10,
+    }
+    applied = {
+        "pct": expected_pct,
+        "page": TEST_PAGE,
+        "cbx_page": TEST_PAGE,
+        "file_page": TEST_PAGE,
+    }
+    client = make_cbx_api_client(None)
+    client.get_progress_rich_by_book_id.side_effect = [
+        None,
+        unchanged,
+        unchanged,
+        applied,
+    ]
+
+    with patch("src.api.booklore_client.time.sleep"):
+        assert client.update_progress(
+            "comic.cbz",
+            expected_pct,
+            LocatorResult(percentage=expected_pct, page=TEST_PAGE),
+        ) is True
+
+    assert client._make_request.call_count == 2
+    assert set(client._make_request.call_args_list[1].args[2]) == {
+        "bookId",
+        "fileProgress",
+    }
+
+
+def test_grimmory_page_less_file_row_degrades_to_cbx_verification():
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    observed = {
+        "pct": expected_pct,
+        "page": TEST_PAGE,
+        "cbx_page": TEST_PAGE,
+        "file_page": None,
+        "file_page_observable": False,
+    }
+    client = make_cbx_api_client(observed)
+
+    assert client.update_progress(
+        "comic.cbz",
+        expected_pct,
+        LocatorResult(percentage=expected_pct, page=TEST_PAGE),
+    ) is True
+
+    assert client._make_request.call_count == 1
+
+
+def test_rich_progress_marks_page_less_file_row_unobservable():
+    client = make_rich_progress_client(
+        {
+            "id": 42,
+            "bookType": "CBX",
+            "cbxProgress": {"page": TEST_PAGE, "percentage": 27.12},
+            "primaryFile": {
+                "id": 77,
+                "bookType": "CBX",
+                "fileProgress": {"progressPercent": 27.12},
+            },
+        }
+    )
+
+    rich = client.get_progress_rich_by_book_id(42)
+
+    assert rich["file_page"] is None
+    assert rich["file_page_observable"] is False
+
+
+def test_rich_progress_uses_page_when_position_data_is_explicitly_null():
+    client = make_rich_progress_client(
+        {
+            "id": 42,
+            "bookType": "CBX",
+            "cbxProgress": {"page": TEST_PAGE, "percentage": 27.12},
+            "primaryFile": {
+                "id": 77,
+                "bookType": "CBX",
+                "fileProgress": {
+                    "positionData": None,
+                    "page": TEST_PAGE,
+                    "progressPercent": 27.12,
+                },
+            },
+        }
+    )
+
+    rich = client.get_progress_rich_by_book_id(42)
+
+    assert rich["file_page"] == TEST_PAGE
+    assert rich["file_page_observable"] is True
+
+
+def test_grimmory_concurrent_remote_page_is_preserved_in_cache():
+    expected_pct = TEST_PAGE / PAGE_COUNT
+    before = {"pct": 10 / PAGE_COUNT, "page": 10, "cbx_page": 10, "file_page": 10}
+    moved = {"pct": 20 / PAGE_COUNT, "page": 20, "cbx_page": 20, "file_page": 20}
+    client = make_cbx_api_client(None)
+    client.get_progress_rich_by_book_id.side_effect = [before, moved, moved]
+
+    with patch("src.api.booklore_client.time.sleep"):
+        assert client.update_progress(
+            "comic.cbz",
+            expected_pct,
+            LocatorResult(percentage=expected_pct, page=TEST_PAGE),
+        ) is True
+
+    assert client._book_id_cache[42]["cbxProgress"]["page"] == 20
+    assert client._book_id_cache[42]["cbxProgress"]["page"] != TEST_PAGE
+
+
+def test_page_count_matches_koreader_mupdf_extension_filter(tmp_path):
+    accepted = [
+        ".bmp", ".gif", ".hdp", ".j2k", ".jb2", ".jbig2", ".jp2",
+        ".jpeg", ".jpg", ".jpx", ".jxr", ".pam", ".pbm", ".pgm",
+        ".pkm", ".png", ".pnm", ".ppm", ".tif", ".tiff", ".wdp", ".webp",
+    ]
+    path = tmp_path / "extensions.cbz"
+    with zipfile.ZipFile(path, "w") as archive:
+        for index, suffix in enumerate(accepted):
+            archive.writestr(f"nested/{index}{suffix.upper()}", b"page")
+        archive.writestr("cover.avif", b"not a KOReader MuPDF CBZ page")
+        archive.writestr("__MACOSX/._001.jpg", b"still counted")
+
+    assert count_cbz_pages(FixedPageParser(path), str(path)) == len(accepted) + 1
+
+
+@pytest.mark.parametrize("kind", ["empty", "corrupt", "missing"])
+def test_invalid_cbz_has_no_invented_page_count(tmp_path, kind):
+    path = tmp_path / f"{kind}.cbz"
+    if kind == "empty":
+        with zipfile.ZipFile(path, "w"):
+            pass
+    elif kind == "corrupt":
+        path.write_bytes(b"not a zip")
+    parser = FixedPageParser(path)
+    if kind == "missing":
+        parser.resolve_book_path.return_value = None
+
+    assert count_cbz_pages(parser, str(path)) is None
+
+
+def test_transient_page_count_failure_is_not_cached(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    parser.resolve_book_path.side_effect = [OSError("temporary NAS failure"), cbz_path]
+
+    assert count_cbz_pages(parser, str(cbz_path)) is None
+    assert count_cbz_pages(parser, str(cbz_path)) == PAGE_COUNT
+    assert parser.resolve_book_path.call_count == 2
+
+
+def test_percentage_page_inverse_and_transition_intervals(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    for page in range(1, PAGE_COUNT + 1):
+        pct = percentage_from_cbz_page(parser, str(cbz_path), page)
+        assert estimate_cbz_page(parser, str(cbz_path), pct) == page
+        if page > 1:
+            just_after_previous = ((page - 1) / PAGE_COUNT) + 1e-9
+            assert estimate_cbz_page(
+                parser, str(cbz_path), just_after_previous, provenance="kosync"
+            ) == page
+
+
+def test_generic_rounded_percentage_uses_nearest_page(cbz_path):
+    parser = FixedPageParser(cbz_path)
+
+    assert estimate_cbz_page(parser, str(cbz_path), 0.2712) == TEST_PAGE
+
+
+def test_koreader_truncated_percentage_uses_strict_interval(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    truncated = int((TEST_PAGE / PAGE_COUNT) * 10_000) / 10_000
+
+    assert estimate_cbz_page(
+        parser, str(cbz_path), truncated, provenance="kosync"
+    ) == TEST_PAGE
+
+
+@pytest.mark.parametrize("page", [0, -1, PAGE_COUNT + 1, 1.5, float("inf")])
+def test_out_of_range_or_invalid_page_has_no_percentage(cbz_path, page):
+    parser = FixedPageParser(cbz_path)
+    assert percentage_from_cbz_page(parser, str(cbz_path), page) is None
+
+
+def test_bare_filename_is_resolved_instead_of_trusted_from_cwd(tmp_path, monkeypatch):
+    cwd_copy = tmp_path / "comic.cbz"
+    with zipfile.ZipFile(cwd_copy, "w") as archive:
+        archive.writestr("one.jpg", b"page")
+    resolved = tmp_path / "library.cbz"
+    with zipfile.ZipFile(resolved, "w") as archive:
+        archive.writestr("one.jpg", b"page")
+        archive.writestr("two.jpg", b"page")
+    parser = FixedPageParser(resolved)
+    monkeypatch.chdir(tmp_path)
+
+    assert count_cbz_pages(parser, "comic.cbz") == 2
+    parser.resolve_book_path.assert_called_once_with("comic.cbz")
+
+
+def test_page_count_uses_per_cycle_cache(cbz_path):
+    parser = FixedPageParser(cbz_path)
+
+    assert count_cbz_pages(parser, str(cbz_path)) == PAGE_COUNT
+    assert count_cbz_pages(parser, str(cbz_path)) == PAGE_COUNT
+    parser.resolve_book_path.assert_called_once_with(str(cbz_path))
+
+
+def test_grimmory_page_with_unavailable_count_never_propagates_stale_percentage(tmp_path):
+    missing = tmp_path / "missing.cbz"
+    parser = FixedPageParser(missing)
+    parser.resolve_book_path.return_value = None
+    grimmory = SimpleNamespace(
+        get_progress_rich=lambda _filename: {
+            "pct": 1.0,
+            "percentage_present": True,
+            "cfi": None,
+            "page": TEST_PAGE,
+            "last_read_time": None,
+            "status": "READING",
+        },
+        is_configured=lambda: True,
+    )
+
+    state = BookloreSyncClient(grimmory, parser).get_service_state(
+        cbz_book(missing), None
+    )
+
+    assert state is None
+
+
+@pytest.mark.parametrize("remote_page", [PAGE_COUNT + 1, 16.7])
+def test_out_of_range_or_fractional_page_is_rejected_on_read(cbz_path, remote_page):
+    parser = FixedPageParser(cbz_path)
+    transport = SimpleNamespace(
+        get_progress_with_metadata=lambda _doc_id: (1.0, str(remote_page), {}),
+        is_configured=lambda: True,
+    )
+
+    assert KoSyncSyncClient(transport, parser).get_service_state(
+        cbz_book(cbz_path), None
+    ) is None
+
+
+def test_fixed_page_policy_skip_is_successful_and_retains_observed_state(cbz_path):
+    parser = FixedPageParser(cbz_path)
+    parser.resolve_book_path.return_value = None
+    transport = SimpleNamespace(
+        update_progress=MagicMock(return_value=True),
+        is_configured=lambda: True,
+    )
+    observed = SimpleNamespace(current={"pct": 0.25, "page": 15, "xpath": "15"})
+    request = UpdateProgressRequest(
+        LocatorResult(percentage=0.5, page=TEST_PAGE), current_state=observed
+    )
+
+    result = KoSyncSyncClient(transport, parser).update_progress(
+        cbz_book(cbz_path), request
+    )
+
+    assert result.success is True
+    assert result.skipped is True
+    assert result.updated_state == observed.current
+    assert SyncManager._sync_result_was_applied(result) is False
+    transport.update_progress.assert_not_called()
+
+
+def test_single_fixed_page_turn_is_significant_below_percentage_threshold():
+    manager = SyncManager.__new__(SyncManager)
+    fixed_client = MagicMock()
+    fixed_client.supports_fixed_page_progress.return_value = True
+    manager.sync_clients = {"KoSync": fixed_client}
+    state = SimpleNamespace(
+        current={"pct": 2 / 401, "page": 2, "_previous_page": 1},
+        previous_pct=1 / 401,
+    )
+    book = SimpleNamespace(
+        original_ebook_filename="long-comic.cbz", ebook_filename=None, duration=None
+    )
+
+    assert manager._has_significant_delta("KoSync", {"KoSync": state}, book) is True
+
+
+def test_estimated_page_does_not_trigger_page_delta_significance():
+    manager = SyncManager.__new__(SyncManager)
+    fixed_client = MagicMock()
+    fixed_client.supports_fixed_page_progress.return_value = True
+    manager.sync_clients = {"KoSync": fixed_client}
+    state = SimpleNamespace(
+        current={
+            "pct": 2 / 401,
+            "page": 2,
+            "_previous_page": 1,
+            "_page_is_estimated": True,
+        },
+        previous_pct=1 / 401,
+    )
+    book = SimpleNamespace(
+        original_ebook_filename="long-comic.cbz", ebook_filename=None, duration=None
+    )
+
+    assert manager._has_fixed_page_delta("KoSync", state, book) is False
+
+
+@pytest.mark.parametrize("suffix", [".cbr", ".cbt", ".cb7"])
+def test_unsupported_cbx_without_primary_file_id_is_safe_skip(suffix):
+    client = make_cbx_api_client({"pct": 0.5, "page": None})
+    client.find_book_by_filename.return_value["primaryFile"].pop("id")
+
+    assert client.update_progress(
+        f"comic{suffix}", 0.5, LocatorResult(percentage=0.5)
+    ) is ProgressWriteOutcome.SKIPPED
+    client._make_request.assert_not_called()
+
+
+@pytest.mark.parametrize("suffix", [".cbr", ".cbt", ".cb7"])
+def test_unsupported_cbx_skip_uses_sync_result_contract(suffix):
+    api = make_cbx_api_client({"pct": 0.5, "page": None})
+    api.find_book_by_filename.return_value["primaryFile"].pop("id")
+    parser = MagicMock()
+    book = cbz_book(Path(f"comic{suffix}"))
+    observed = cycle_state(0.25)
+
+    result = BookloreSyncClient(api, parser).update_progress(
+        book,
+        UpdateProgressRequest(
+            LocatorResult(percentage=0.5), current_state=observed
+        ),
+    )
+
+    assert result.success is True
+    assert result.skipped is True
+    assert result.updated_state == observed.current
+    api._make_request.assert_not_called()
+
+
+@pytest.mark.parametrize("client_name", ["ABS Ebook", "BookOrbit", "Storyteller"])
+def test_non_fixed_page_clients_never_receive_a_page_as_fake_cfi(client_name):
+    client = MagicMock(name=client_name)
+    client.supports_fixed_page_progress.return_value = False
+    state = SimpleNamespace(current={"pct": 0.5, "page": TEST_PAGE})
+
+    locator = SyncManager._fixed_page_locator_from_state(client, state, 0.5)
+
+    assert locator.page is None
+    assert locator.cfi is None
+    assert "bookbridge" not in repr(locator)
+
+
+def test_non_cbz_aware_leader_cannot_invent_cbz_page():
+    client = MagicMock()
+    client.supports_fixed_page_progress.return_value = False
+    state = SimpleNamespace(current={"pct": 0.6949, "cfi": "epubcfi(/6/2)"})
+
+    locator = SyncManager._fixed_page_locator_from_state(client, state, 0.6949)
+
+    assert locator == LocatorResult(percentage=0.6949)
+
+
+def test_abs_ebook_never_writes_fixed_page_as_cfi():
+    transport = MagicMock()
+    client = ABSEbookSyncClient(transport, MagicMock())
+    book = Book(abs_id="abs-book", ebook_filename="comic.cbz")
+
+    result = client.update_progress(
+        book, UpdateProgressRequest(LocatorResult(percentage=0.5, page=TEST_PAGE))
+    )
+
+    assert result.success is False
+    transport.update_ebook_progress.assert_not_called()
+
+
+def test_bookorbit_never_serializes_fixed_page_as_cfi():
+    client = BookOrbitClient.__new__(BookOrbitClient)
+    client._make_request = MagicMock(return_value=SimpleNamespace(status_code=204))
+
+    assert client.update_ebook_progress(
+        {"id": 42, "ebookFileId": 77},
+        0.5,
+        LocatorResult(percentage=0.5, page=TEST_PAGE),
+    ) is True
+
+    payload = client._make_request.call_args.args[2]
+    assert payload == {"percentage": 50.0}
+
+
+def test_storyteller_never_serializes_fixed_page_as_cfi():
+    client = StorytellerAPIClient.__new__(StorytellerAPIClient)
+
+    payload = client._build_position_payload(
+        "book-uuid", 0.5, LocatorResult(percentage=0.5, page=TEST_PAGE)
+    )
+
+    locations = payload["locator"]["locations"]
+    assert locations == {"totalProgression": 0.5}
+    assert "bookbridge" not in repr(payload)
+
+
+def test_coerce_page_rejects_fractional_and_nonfinite_values():
+    assert coerce_page("16") == 16
+    assert coerce_page(16.5) is None
+    assert coerce_page(float("nan")) is None

--- a/tests/test_kavita_sync_client.py
+++ b/tests/test_kavita_sync_client.py
@@ -86,3 +86,41 @@ def test_zero_progress_uses_locator_kavita_accepts_and_records_own_write():
         "deadbeef", 0.0, "/body/DocFragment[1].0"
     )
     record_write.assert_called_once_with("Kavita", "book-1", 0.0)
+
+
+def test_cbz_does_not_enter_inherited_kosync_fixed_page_protocol():
+    api = MagicMock()
+    api.update_progress.return_value = True
+    parser = MagicMock()
+    parser.get_sentence_level_ko_xpath.side_effect = AssertionError("CBZ must not generate EPUB XPath")
+    parser.extract_text_and_map.side_effect = AssertionError("CBZ must not use EPUB parsing")
+    client = KavitaSyncClient(api, parser)
+    book = _book(ebook_filename="comic.cbz")
+
+    result = client.update_progress(
+        book, UpdateProgressRequest(LocatorResult(percentage=0.5, page=16))
+    )
+
+    assert client.supports_fixed_page_progress() is False
+    assert result.success is True
+    assert result.skipped is True
+    api.update_progress.assert_not_called()
+    parser.get_sentence_level_ko_xpath.assert_not_called()
+    parser.extract_text_and_map.assert_not_called()
+
+
+def test_cbz_read_is_percentage_only_without_epub_xpath_resolution():
+    api = MagicMock()
+    api.is_configured.return_value = True
+    api.get_progress_with_metadata.return_value = (0.4, "16", {"timestamp": 123})
+    parser = MagicMock()
+    parser.resolve_xpath_to_index.side_effect = AssertionError("CBZ must not resolve EPUB XPath")
+    parser.extract_text_and_map.side_effect = AssertionError("CBZ must not use EPUB parsing")
+    client = KavitaSyncClient(api, parser)
+
+    state = client.get_service_state(_book(ebook_filename="comic.cbz"), None)
+
+    assert state.current["pct"] == 0.4
+    assert state.current["xpath"] is None
+    parser.resolve_xpath_to_index.assert_not_called()
+    parser.extract_text_and_map.assert_not_called()

--- a/tests/test_kosync_sync_client_canonical.py
+++ b/tests/test_kosync_sync_client_canonical.py
@@ -27,7 +27,6 @@ def install_stubs():
 
     progress_metadata = types.ModuleType("src.utils.progress_metadata")
     progress_metadata.parse_service_timestamp = lambda value: value
-    progress_metadata.get_kosync_approved_rewind_at = lambda state: None
     sys.modules[progress_metadata.__name__] = progress_metadata
 
     iface = types.ModuleType("src.sync_clients.sync_client_interface")
@@ -49,6 +48,10 @@ def install_stubs():
         def __init__(self, locator_result):
             self.locator_result = locator_result
 
+    class LocatorResult:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
     class ServiceState:
         def __init__(self, **kwargs):
             self.__dict__.update(kwargs)
@@ -56,6 +59,7 @@ def install_stubs():
     iface.SyncClient = SyncClient
     iface.SyncResult = SyncResult
     iface.UpdateProgressRequest = UpdateProgressRequest
+    iface.LocatorResult = LocatorResult
     iface.ServiceState = ServiceState
     sys.modules[iface.__name__] = iface
 
@@ -124,8 +128,7 @@ class KoSyncSyncClientCanonicalTests(unittest.TestCase):
         self.path.unlink(missing_ok=True)
 
     def _request(self, pct):
-        return SimpleNamespace(locator_result=SimpleNamespace(percentage=pct),
-                               allow_rewind=False, current_state=None)
+        return SimpleNamespace(locator_result=SimpleNamespace(percentage=pct))
 
     def _book(self):
         return SimpleNamespace(


### PR DESCRIPTION
## Summary

Add first-class fixed-page progress handling for CBZ books so KOReader/KoSync and Grimmory stay consistent without forcing comics through EPUB locator semantics.

## Problem

CBZ mappings could expose a concrete page and a conflicting percentage at the same time. Treating those values like ordinary EPUB progress allowed KoSync and Grimmory to disagree, flip between percentages, or propagate stale progress.

A fixed-page comic has a discrete page position. When the archive page count is reliable, the concrete page should be authoritative and the percentage should be derived from it.

## Fix

- represent fixed-page position as a first-class `LocatorResult.page` instead of a fake CFI/XPath;
- explicitly gate clients that support fixed-page progress;
- canonicalize CBZ percentage from the concrete page in both read and write directions;
- keep CBZ out of EPUB text/alignment/XPath paths;
- make one page turn significant even when it is below the normal percentage threshold;
- handle reset, missing page count and out-of-range pages safely;
- distinguish KOReader-truncated percentage semantics from generic rounded percentage-to-page conversion;
- update and verify Grimmory CBX/file-level progress instead of trusting HTTP success alone;
- avoid fabricated page values for unsupported comic formats;
- count WebP image entries used by KOReader in CBZ archives.

## WebP case

A real 58-page comic can be stored as:

```text
58 x .webp
1 x .xml
```

The page count must resolve to 58, so for example:

```text
page 24 -> 41.3793%
page 58 -> 100%
```

## Safety / regressions

The branch includes regression coverage for non-CBX progress semantics, missing page counts, rounded percentages, long comics, Grimmory write verification, concurrent read-back, unsupported comic formats and non-page clients. EPUB/PDF progress semantics remain unchanged.

Live validation with WebP-based CBZ files confirms page-aware progress is canonicalized and propagated consistently between KoSync and Grimmory.

## Scope

This PR is limited to fixed-page CBZ progress. Grimmory filename-rename resilience, cover routing, KoSync multi-device sibling policy and deployment workflows are intentionally separate.