### PR TITLE
[Fix] Keep Grimmory mappings stable across filename changes

### DIFF
--- a/src/api/booklore_client.py
+++ b/src/api/booklore_client.py
@@ -16,6 +16,11 @@ from src.utils.file_transfers import (
     stream_response_to_path,
 )
 from src.utils.logging_utils import sanitize_log_data
+from src.utils.ebook_sources import (
+    is_grimmory_source,
+    is_storyteller_filename,
+    normalize_ebook_source,
+)
 from src.sync_clients.sync_client_interface import LocatorResult
 from src.utils.user_config import resolve_setting
 
@@ -55,6 +60,7 @@ class BookloreClient:
         self._book_id_cache = {}
         # Memoized LLM filename-rescue verdicts (stem -> cached filename or None)
         self._llm_filename_match_cache = {}
+        self._exact_filename_miss_cache = {}
         self._cache_timestamp = 0
         self._last_refresh_failed = False
         self._last_refresh_attempt = 0
@@ -859,6 +865,7 @@ class BookloreClient:
             return True
 
         self._llm_filename_match_cache = {}
+        self._exact_filename_miss_cache = {}
         self._last_refresh_attempt = time.time()
         try:
             all_books_list = []
@@ -1255,12 +1262,145 @@ class BookloreClient:
 
         return None
 
+    def reconcile_mapping_filename_drift(self):
+        """Refresh mapped external filenames while preserving local identity.
+
+        ``ebook_source_id`` is authoritative for existing Grimmory mappings.  A
+        filename change for that same id updates only ``ebook_filename``; the
+        original/local filename, KoSync hash, progress state, alignment, and status
+        are intentionally left untouched.  Legacy mappings may acquire a source id
+        only from one unambiguous, case-insensitive exact filename match.
+        """
+        if not self.db or not hasattr(self.db, "get_all_books"):
+            return 0
+        try:
+            mappings = list(self.db.get_all_books() or [])
+        except Exception:
+            logger.warning("Grimmory: Could not load mappings for filename reconciliation", exc_info=True)
+            return 0
+
+        by_id = {}
+        ids_by_filename = {}
+        incomplete_filename_catalog = False
+        for cached_id, book_info in self._snapshot_book_id_items():
+            if not isinstance(book_info, dict):
+                continue
+            raw_id = book_info.get("id")
+            if raw_id is None:
+                raw_id = cached_id
+            if raw_id is None:
+                continue
+            stable_id = str(raw_id)
+            by_id[stable_id] = book_info
+            filename = book_info.get("fileName")
+            if filename:
+                ids_by_filename.setdefault(Path(str(filename)).name.lower(), set()).add(stable_id)
+            elif book_info.get("_needs_detail"):
+                incomplete_filename_catalog = True
+
+        claimed_ids = {
+            str(getattr(mapping, "ebook_source_id", "") or "").strip()
+            for mapping in mappings
+            if is_grimmory_source(getattr(mapping, "ebook_source", None))
+            and str(getattr(mapping, "ebook_source_id", "") or "").strip()
+        }
+        pending_legacy_claims = {}
+        if not incomplete_filename_catalog:
+            for mapping in mappings:
+                if not is_grimmory_source(getattr(mapping, "ebook_source", None)):
+                    continue
+                if str(getattr(mapping, "ebook_source_id", None) or "").strip():
+                    continue
+                candidate_ids = set()
+                for filename in (
+                    getattr(mapping, "ebook_filename", None),
+                    getattr(mapping, "original_ebook_filename", None),
+                ):
+                    if filename:
+                        candidate_ids.update(
+                            ids_by_filename.get(Path(str(filename)).name.lower(), set())
+                        )
+                if len(candidate_ids) == 1:
+                    candidate_id = next(iter(candidate_ids))
+                    pending_legacy_claims.setdefault(candidate_id, []).append(mapping)
+
+        updated_count = 0
+        for mapping in mappings:
+            source = getattr(mapping, "ebook_source", None)
+            if not isinstance(source, str) or not is_grimmory_source(source):
+                continue
+
+            source_id = str(getattr(mapping, "ebook_source_id", None) or "").strip()
+            remote = by_id.get(source_id) if source_id else None
+            fields = {}
+            backfilled = False
+            if not source_id:
+                candidates = [
+                    candidate_id
+                    for candidate_id, candidate_mappings in pending_legacy_claims.items()
+                    if len(candidate_mappings) == 1 and candidate_mappings[0] is mapping
+                ]
+                if len(candidates) != 1 or candidates[0] in claimed_ids:
+                    continue
+                source_id = candidates[0]
+                remote = by_id.get(source_id)
+                canonical_source = normalize_ebook_source(source)
+                claim = getattr(self.db, "backfill_ebook_source_id_if_unclaimed", None)
+                if not callable(claim) or not claim(mapping.abs_id, source_id, canonical_source):
+                    continue
+                claimed_ids.add(source_id)
+                mapping.ebook_source = canonical_source
+                mapping.ebook_source_id = source_id
+                backfilled = True
+                logger.info(
+                    "Grimmory mapping source id backfilled for %s: %s (exact filename match)",
+                    getattr(mapping, "abs_id", "?"), source_id,
+                )
+
+            # A known id missing from the refreshed catalog is not a rename. Do not
+            # fall back to filename and risk silently relinking another resource.
+            if not remote:
+                continue
+            current_filename = str(remote.get("fileName") or "").strip()
+            stored_filename = str(getattr(mapping, "ebook_filename", None) or "").strip()
+            is_storyteller_artifact = is_storyteller_filename(stored_filename)
+            if current_filename and stored_filename != current_filename and not is_storyteller_artifact:
+                old_filename = stored_filename
+                fields["ebook_filename"] = current_filename
+                logger.info(
+                    "Grimmory mapping filename refreshed for %s: %s -> %s "
+                    "(source id unchanged: %s)",
+                    getattr(mapping, "abs_id", "?"), old_filename or "<empty>",
+                    current_filename, source_id,
+                )
+
+            if not fields:
+                if backfilled:
+                    updated_count += 1
+                continue
+            try:
+                saved = self.db.update_book_fields(
+                    mapping.abs_id,
+                    expected_ebook_source_id=source_id,
+                    expected_grimmory_source=True,
+                    notify_catalog_change=True,
+                    **fields,
+                )
+            except Exception:
+                logger.warning(
+                    "Grimmory: Failed to persist mapping reconciliation for %s",
+                    getattr(mapping, "abs_id", "?"), exc_info=True,
+                )
+                continue
+            if saved:
+                updated_count += 1
+        return updated_count
+
     def _fetch_and_cache_detail(self, book_id, force_refresh=False):
         """Fetch detail for a single book on demand and add it to cache."""
-        with self._cache_lock:
-            cached = self._book_id_cache.get(book_id)
-            if cached and not cached.get('_needs_detail') and not force_refresh:
-                return cached
+        cached = self._get_cached_book_by_id(book_id)
+        if cached and not cached.get('_needs_detail') and not force_refresh:
+            return cached
 
         token = self._get_fresh_token()
         if not token:
@@ -1269,8 +1409,10 @@ class BookloreClient:
         detail = self._fetch_book_detail(book_id, token)
         if detail and isinstance(detail, dict):
             self._process_book_detail(detail)
-            with self._cache_lock:
-                return self._book_id_cache.get(book_id)
+            # API ids are commonly integers while persisted mapping ids are
+            # strings. Resolve by value so a cold-cache write for source id "4"
+            # can use a detail response keyed as integer 4.
+            return self._get_cached_book_by_id(book_id)
         return None
 
     def _get_cached_book_by_id(self, book_id):
@@ -1386,6 +1528,61 @@ class BookloreClient:
         if allow_refresh:
             return self._llm_match_by_filename(target_stem)
         return None
+
+    def find_book_by_filename_exact(self, ebook_filename, allow_refresh=True):
+        """Find a Grimmory book by its current filename without fuzzy relinking.
+
+        This resolver is intended for legacy BookBridge mappings which do not yet
+        have a stable ``ebook_source_id``.  Case-insensitive basename equality is
+        the only accepted match; stem, partial, fuzzy, and LLM matches are
+        deliberately excluded because a successful result may be persisted as the
+        mapping's stable external identity.
+        """
+        if not ebook_filename:
+            return None
+        target_name = Path(str(ebook_filename)).name.lower()
+        now = time.time()
+        missed_at = self._exact_filename_miss_cache.get(target_name)
+        if missed_at is not None and now - missed_at < self._refresh_cooldown:
+            return None
+        if not self._has_cached_books() and allow_refresh and not self._is_refresh_on_cooldown():
+            self._refresh_book_cache()
+        exact_match = self._get_unique_exact_filename_match(target_name)
+        if exact_match is not None:
+            self._exact_filename_miss_cache.pop(target_name, None)
+            return exact_match
+        if allow_refresh and now - self._cache_timestamp > 3600 and not self._is_refresh_on_cooldown():
+            if self._refresh_book_cache():
+                exact_match = self._get_unique_exact_filename_match(target_name)
+                if exact_match is not None:
+                    self._exact_filename_miss_cache.pop(target_name, None)
+                    return exact_match
+        self._exact_filename_miss_cache[target_name] = time.time()
+        return None
+
+    def _get_unique_exact_filename_match(self, target_name):
+        """Return one catalog-wide exact filename match, never an ambiguity."""
+        matching_ids = set()
+        for cached_id, info in self._snapshot_book_id_items():
+            if not isinstance(info, dict):
+                continue
+            filename = info.get("fileName")
+            if not filename:
+                if info.get("_needs_detail"):
+                    # An unhydrated entry can conceal another exact match.
+                    return None
+                continue
+            if Path(str(filename)).name.lower() == target_name:
+                raw_id = info.get("id")
+                matching_ids.add(str(cached_id if raw_id is None else raw_id))
+        if len(matching_ids) != 1:
+            return None
+        with self._cache_lock:
+            match = self._book_cache.get(target_name)
+        if not isinstance(match, dict):
+            return None
+        raw_id = match.get("id")
+        return match if str(raw_id) in matching_ids else None
 
     def _llm_match_by_filename(self, target_stem):
         """Judge-confirmed rescue over the cached book list. Returns book_info or None."""
@@ -1523,6 +1720,7 @@ class BookloreClient:
             with self._cache_lock:
                 self._book_cache = {}
                 self._book_id_cache = {}
+                self._exact_filename_miss_cache = {}
                 self._cache_timestamp = 0
 
             self._last_refresh_failed = False
@@ -1955,11 +2153,15 @@ class BookloreClient:
             'track_position_ms': self._to_optional_int(progress.get('trackPositionMs')),
         }
 
+    def get_progress_by_book_id(self, book_id):
+        """Get progress directly from Grimmory's stable book identity."""
+        return self._get_progress_by_book_id(book_id)
+
     def get_progress(self, ebook_filename):
         book = self.find_book_by_filename(ebook_filename)
         if not book:
             return None, None
-        return self._get_progress_by_book_id(book['id'])
+        return self.get_progress_by_book_id(book['id'])
 
     def get_progress_rich(self, ebook_filename):
         """Progress plus Grimmory's own metadata for a filename, or None.
@@ -1972,12 +2174,31 @@ class BookloreClient:
         book = self.find_book_by_filename(ebook_filename)
         if not book:
             return None
-        response = self._make_request("GET", f"/api/v1/books/{book['id']}")
-        if not response or response.status_code != 200:
+        return self.get_progress_rich_by_book_id(book['id'])
+
+    def get_progress_rich_by_book_id(self, book_id):
+        """Return rich progress directly for a stable Grimmory book id."""
+        response = self._make_request("GET", f"/api/v1/books/{book_id}")
+        if not response:
             return None
-        data = self._parse_json_response(response, f"Grimmory rich progress for book {book['id']}")
+        if response.status_code == 404:
+            self._evict_cached_book(book_id=book_id, reason="rich progress lookup returned 404")
+            return None
+        if response.status_code != 200:
+            return None
+        data = self._parse_json_response(response, f"Grimmory rich progress for book {book_id}")
         if not isinstance(data, dict):
             return None
+
+        # Reuse this same detail for an immediately following write. Identity is
+        # still the requested id; caching only removes a redundant hydration GET.
+        # Some lightweight integrations construct a read-only client via
+        # ``__new__``; leave parsing functional when no cache was initialized.
+        if all(
+            hasattr(self, attr)
+            for attr in ("_cache_lock", "_book_cache", "_book_id_cache")
+        ):
+            self._process_book_detail(data)
 
         book_type = str(
             data.get('primaryFile', {}).get('bookType')
@@ -2243,6 +2464,25 @@ class BookloreClient:
         if not book:
             logger.debug(f"Grimmory: Book not found: {ebook_filename}")
             return False
+
+        return self._update_progress_for_book(book, ebook_filename, percentage, rich_locator)
+
+    def update_progress_by_book_id(self, book_id, percentage, rich_locator: Optional[LocatorResult] = None):
+        """Write progress directly to a mapped Grimmory book id.
+
+        A cached hydrated detail avoids an extra GET.  When metadata is absent we
+        fetch only this book by id; a full library refresh and filename lookup are
+        never used to resolve identity.
+        """
+        book = self.get_book_by_id(book_id)
+        if not book:
+            logger.debug("Grimmory: Book id not found: %s", book_id)
+            return False
+        display_filename = book.get('fileName') or f"book-id:{book_id}"
+        return self._update_progress_for_book(book, display_filename, percentage, rich_locator)
+
+    def _update_progress_for_book(self, book, ebook_filename, percentage, rich_locator=None):
+        """Shared write implementation after identity has already been resolved."""
 
         safe_filename = sanitize_log_data(ebook_filename)
         book_id = book['id']
@@ -3159,4 +3399,3 @@ class BookloreClient:
             )
             return False
         return True
-

--- a/src/api/kosync_server.py
+++ b/src/api/kosync_server.py
@@ -34,6 +34,7 @@ from src.utils.user_config import (
     resolve_setting,
 )
 from src.utils.string_utils import calculate_similarity, clean_book_title
+from src.utils.ebook_sources import is_grimmory_source
 from src.services import observation_trail
 from src.services.llm_matching import judge_best_candidate
 from src.db.models import State
@@ -1565,7 +1566,7 @@ def _auto_map_ebook_to_audiobook(doc_hash_val, epub_filename, candidate, reason)
         audio_cover_url=f"/api/cover-proxy/{candidate['abs_id']}",
         ebook_source=ebook_source,
         ebook_source_id=ebook_source_id,
-        booklore_ebook_id=ebook_source_id if ebook_source == "BookLore" else None,
+        booklore_ebook_id=ebook_source_id if is_grimmory_source(ebook_source) else None,
         kosync_doc_id=doc_hash_val,
     )
     if not saved:

--- a/src/db/database_service.py
+++ b/src/db/database_service.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+import threading
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -46,6 +47,7 @@ from .models import (
 )
 from src.services.map_quality import ALIGNMENT_QUALITY_REALIGN_THRESHOLD, quality_detail_json, score_map
 from src.utils import secret_store
+from src.utils.ebook_sources import source_name_variants
 from src.utils.time_utils import utcnow
 
 logger = logging.getLogger(__name__)
@@ -100,6 +102,7 @@ class DatabaseService:
         self.db_manager = DatabaseManager(str(self.db_path))
         self._default_uid = None  # cached default (admin) user id for state scoping
         self._catalog_change_callbacks: list[Callable[[], None]] = []
+        self._ebook_source_claim_lock = threading.Lock()
 
         # Run Alembic migrations to ensure schema is up to date
         self._run_alembic_migrations()
@@ -577,7 +580,15 @@ class DatabaseService:
             self._notify_catalog_change()
         return bool(updated)
 
-    def update_book_fields(self, abs_id: str, **fields) -> bool:
+    def update_book_fields(
+        self,
+        abs_id: str,
+        *,
+        expected_ebook_source_id: Optional[str] = None,
+        expected_grimmory_source: bool = False,
+        notify_catalog_change: bool = False,
+        **fields,
+    ) -> bool:
         """Update named columns on one book row, leaving `abs_id` alone.
 
         Used by the audio repoint, which changes a book's audio provider in place:
@@ -594,11 +605,22 @@ class DatabaseService:
         if not allowed:
             return False
         with self.get_session() as session:
-            updated = session.query(Book).filter(Book.abs_id == abs_id).update(
+            query = session.query(Book).filter(Book.abs_id == abs_id)
+            if expected_ebook_source_id is not None:
+                query = query.filter(Book.ebook_source_id == str(expected_ebook_source_id))
+            if expected_grimmory_source:
+                from sqlalchemy import func
+
+                query = query.filter(
+                    func.lower(Book.ebook_source).in_(("booklore", "grimmory"))
+                )
+            updated = query.update(
                 {getattr(Book, key): value for key, value in allowed.items()},
                 synchronize_session=False,
             )
-            return bool(updated)
+        if updated and notify_catalog_change:
+            self._notify_catalog_change()
+        return bool(updated)
 
     def has_alignment(self, abs_id: str) -> bool:
         """Whether a stored alignment map exists for a book.
@@ -1046,6 +1068,44 @@ class DatabaseService:
             session.refresh(existing)
             session.expunge(existing)
             return existing
+
+    def backfill_ebook_source_id_if_unclaimed(
+        self,
+        abs_id: str,
+        source_id: str,
+        ebook_source: str = "Booklore",
+    ) -> bool:
+        """Claim a legacy Grimmory id only when no other mapping owns it."""
+        from sqlalchemy import func
+
+        stable_id = str(source_id or "").strip()
+        if not abs_id or not stable_id:
+            return False
+        with self._ebook_source_claim_lock:
+            with self.get_session() as session:
+                conflict = session.query(Book.abs_id).filter(
+                    Book.abs_id != abs_id,
+                    Book.ebook_source_id == stable_id,
+                    func.lower(Book.ebook_source).in_(("booklore", "grimmory")),
+                ).first()
+                if conflict:
+                    return False
+                updated = session.query(Book).filter(
+                    Book.abs_id == abs_id,
+                    (Book.ebook_source_id.is_(None)) | (Book.ebook_source_id == ""),
+                    func.lower(func.trim(func.coalesce(Book.ebook_source, ""))).in_(
+                        ("", "booklore", "grimmory")
+                    ),
+                ).update(
+                    {
+                        "ebook_source": ebook_source,
+                        "ebook_source_id": stable_id,
+                    },
+                    synchronize_session=False,
+                )
+        if updated:
+            self._notify_catalog_change()
+        return bool(updated)
 
     def migrate_book_data(self, old_abs_id: str, new_abs_id: str):
         """
@@ -2210,11 +2270,13 @@ class DatabaseService:
 
     def get_book_by_ebook_source(self, ebook_source: str, ebook_source_id: str) -> Optional['Book']:
         """Find a book by its ebook source + source id (e.g. BookLore/<grimmory_id>)."""
-        if not ebook_source or not ebook_source_id:
+        variants = source_name_variants(ebook_source)
+        if not variants or not ebook_source_id:
             return None
+        from sqlalchemy import func
         with self.get_session() as session:
             book = session.query(Book).filter(
-                Book.ebook_source == ebook_source,
+                func.lower(func.trim(Book.ebook_source)).in_(variants),
                 Book.ebook_source_id == str(ebook_source_id),
             ).first()
             if book:
@@ -5206,5 +5268,3 @@ class DatabaseMigrator:
             return True
 
         return False
-
-

--- a/src/services/library_service.py
+++ b/src/services/library_service.py
@@ -13,6 +13,12 @@ from src.db.database_service import DatabaseService
 from src.api.api_clients import ABSClient
 from src.api.cwa_client import CWAClient
 from src.utils.cache_paths import safe_cache_path
+from src.utils.ebook_sources import (
+    is_grimmory_source,
+    is_storyteller_filename,
+    local_ebook_filename,
+    normalize_ebook_source,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,24 +64,29 @@ class LibraryService:
         if book and book.ebook_source and book.ebook_source_id:
             # Skip tri-linked mappings where ebook_filename names the Storyteller artifact
             # while ebook_source_id points at the source library book.
-            if book.ebook_filename and book.ebook_filename.startswith("storyteller_"):
+            if is_storyteller_filename(book.ebook_filename):
                 logger.debug("   Priority 0 (Explicit mapping): Skipped — ebook_filename is a Storyteller artifact")
             else:
                 # Map source to client
                 client = None
                 source_name = book.ebook_source
-                if source_name == "BookOrbit":
+                normalized_source = normalize_ebook_source(source_name)
+                if normalized_source == "BookOrbit":
                     client = self.bookorbit_client
-                elif source_name == "BookLore":
+                elif is_grimmory_source(source_name):
                     client = self.booklore
-                elif source_name == "Kavita":
+                elif normalized_source == "Kavita":
                     client = self.kavita_client
                 # Any other source is not supported here
                 
                 if client and getattr(client, "is_configured", lambda: True)():
-                    # Resolve cache destination using the mapping's own filename
-                    if book.ebook_filename:
-                        cache_path = safe_cache_path(self.epub_cache_dir, book.ebook_filename)
+                    # ``ebook_filename`` is mutable external metadata. Keep using
+                    # the original local cache name when a source-side rename is
+                    # reconciled so filename drift alone does not redownload bytes
+                    # or change the KoSync document identity.
+                    local_filename = local_ebook_filename(book)
+                    if local_filename:
+                        cache_path = safe_cache_path(self.epub_cache_dir, local_filename)
                         if cache_path:
                             # Return cached file if it exists and is substantial
                             if cache_path.exists() and cache_path.stat().st_size > 1024:
@@ -220,10 +231,9 @@ class LibraryService:
             
             all_books = self.booklore.get_all_books()
             logger.info(f"   📚 Grimmory cache is active with {len(all_books)} books.")
-            
-            # FUTURE: If we want to ensure DB sync for fields that changed without ID change,
-            # we could do it here, but efficiently. For now, trust the client's cache logic.
+            reconcile = getattr(self.booklore, "reconcile_mapping_filename_drift", None)
+            if callable(reconcile):
+                reconcile()
             
         except Exception as e:
             logger.error(f"   ❌ Library sync failed: {e}", exc_info=True)
-

--- a/src/sync_clients/booklore_sync_client.py
+++ b/src/sync_clients/booklore_sync_client.py
@@ -6,6 +6,7 @@ from src.api.booklore_client import BookloreClient
 from src.db.models import Book, State
 from src.utils.ebook_utils import EbookParser
 from src.utils.progress_metadata import parse_service_timestamp
+from src.utils.ebook_sources import is_grimmory_source, normalize_ebook_source
 from src.sync_clients.sync_client_interface import SyncClient, SyncResult, UpdateProgressRequest, ServiceState
 
 logger = logging.getLogger(__name__)
@@ -30,18 +31,74 @@ class BookloreSyncClient(SyncClient):
     def _resolve_epub_filename(book: Book) -> Optional[str]:
         return getattr(book, "original_ebook_filename", None) or getattr(book, "ebook_filename", None)
 
+    @staticmethod
+    def _mapped_book_id(book: Book) -> Optional[str]:
+        source = getattr(book, "ebook_source", None)
+        source_id = getattr(book, "ebook_source_id", None)
+        if not isinstance(source, str) or not is_grimmory_source(source):
+            return None
+        if not isinstance(source_id, (str, int)) or not str(source_id).strip():
+            return None
+        return str(source_id).strip()
+
+    def _resolve_legacy_book_id(self, book: Book, epub: Optional[str]) -> Optional[str]:
+        """Resolve and safely backfill an exact legacy filename match."""
+        if not epub:
+            return None
+        source = getattr(book, "ebook_source", None)
+        if source is not None and (
+            not isinstance(source, str)
+            or (source.strip() and not is_grimmory_source(source))
+        ):
+            return None
+        exact_resolver = getattr(self.booklore_client, "find_book_by_filename_exact", None)
+        target = exact_resolver(epub) if callable(exact_resolver) else None
+        if not isinstance(target, dict) or target.get("id") in (None, ""):
+            return None
+
+        book_id = str(target["id"])
+        original_source = source
+        book.ebook_source = normalize_ebook_source(source or "Booklore")
+        book.ebook_source_id = book_id
+        db = getattr(self.booklore_client, "db", None)
+        claim = getattr(db, "backfill_ebook_source_id_if_unclaimed", None)
+        if callable(claim):
+            try:
+                if not claim(book.abs_id, book_id, book.ebook_source):
+                    logger.warning(
+                        "Grimmory mapping source-id backfill refused for %s: id %s is already claimed",
+                        getattr(book, "abs_id", "?"), book_id,
+                    )
+                    book.ebook_source = original_source
+                    book.ebook_source_id = None
+                    return None
+                logger.info(
+                    "Grimmory mapping source id backfilled for %s: %s (exact filename: %s)",
+                    getattr(book, "abs_id", "?"), book_id, epub,
+                )
+            except Exception:
+                logger.warning(
+                    "Grimmory mapping source-id backfill failed for %s",
+                    getattr(book, "abs_id", "?"), exc_info=True,
+                )
+                book.ebook_source = original_source
+                book.ebook_source_id = None
+                return None
+        return book_id
+
     def supports_book(self, book: Book) -> bool:
         epub = self._resolve_epub_filename(book)
-        if not epub:
-            return False
 
         # An explicit ebook source is authoritative. Match Grimmory regardless of
         # the tag variant it was saved under ('BookLore'/'Booklore'/'Grimmory');
         # never hijack a book explicitly owned by another ebook source (e.g.
         # BookOrbit), even if Grimmory hosts the same file.
-        src = (getattr(book, "ebook_source", None) or "").strip().lower()
+        src = str(getattr(book, "ebook_source", None) or "").strip()
         if src:
-            return src in ("booklore", "grimmory")
+            return is_grimmory_source(src) and bool(self._mapped_book_id(book) or epub)
+
+        if not epub:
+            return False
 
         # Otherwise (legacy/unsourced) only participate when the ebook can actually
         # be resolved against the Grimmory library cache.
@@ -56,14 +113,29 @@ class BookloreSyncClient(SyncClient):
         # readStatus); non-dict results (older/mocked clients) fall back to the
         # classic (pct, cfi) tuple.
         rich = None
-        if hasattr(self.booklore_client, "get_progress_rich"):
+        book_id = self._mapped_book_id(book) or self._resolve_legacy_book_id(book, epub)
+        direct_rich_attempted = False
+        if book_id and hasattr(self.booklore_client, "get_progress_rich_by_book_id"):
+            direct_rich_attempted = True
+            candidate = self.booklore_client.get_progress_rich_by_book_id(book_id)
+            if isinstance(candidate, dict):
+                rich = candidate
+        elif hasattr(self.booklore_client, "get_progress_rich"):
             candidate = self.booklore_client.get_progress_rich(epub)
             if isinstance(candidate, dict):
                 rich = candidate
         if rich is not None:
             bl_pct, bl_cfi = rich.get("pct"), rich.get("cfi")
+        elif direct_rich_attempted:
+            # The rich endpoint is the same GET /books/{id} used by the classic
+            # read. A second call cannot improve identity resolution and turns a
+            # 404/transient failure into needless duplicate traffic.
+            bl_pct, bl_cfi = None, None
         else:
-            bl_pct, bl_cfi = self.booklore_client.get_progress(epub)
+            if book_id and hasattr(self.booklore_client, "get_progress_by_book_id"):
+                bl_pct, bl_cfi = self.booklore_client.get_progress_by_book_id(book_id)
+            else:
+                bl_pct, bl_cfi = self.booklore_client.get_progress(epub)
 
         if bl_pct is None:
             logger.debug("Grimmory percentage is None - returning no service state")
@@ -110,7 +182,11 @@ class BookloreSyncClient(SyncClient):
         # Prefer the original filename for updates too.
         epub = self._resolve_epub_filename(book)
         pct = request.locator_result.percentage
-        success = self.booklore_client.update_progress(epub, pct, request.locator_result)
+        book_id = self._mapped_book_id(book) or self._resolve_legacy_book_id(book, epub)
+        if book_id and hasattr(self.booklore_client, "update_progress_by_book_id"):
+            success = self.booklore_client.update_progress_by_book_id(book_id, pct, request.locator_result)
+        else:
+            success = self.booklore_client.update_progress(epub, pct, request.locator_result)
         if success:
             try:
                 from src.services.write_tracker import record_write

--- a/src/sync_manager.py
+++ b/src/sync_manager.py
@@ -55,6 +55,12 @@ from src.utils.transcription_cancel import (
 from src.utils.transcriber import TranscriptionCancelled
 from src.utils.logging_utils import sanitize_log_data, get_persistent_condition_logger
 from src.utils.progress_metadata import state_metadata_kwargs
+from src.utils.ebook_sources import (
+    is_grimmory_source,
+    is_storyteller_filename,
+    local_ebook_filename,
+    normalize_ebook_source,
+)
 
 # Service imports
 from src.services.alignment_service import AlignmentService, ingest_storyteller_transcripts
@@ -1746,7 +1752,7 @@ class SyncManager:
         """
         # 1. Skip Storyteller artifacts — they have their own materialization path
         #    and caching the library bytes under a Storyteller filename would be wrong.
-        if ebook_filename.startswith("storyteller_"):
+        if is_storyteller_filename(ebook_filename):
             return None
 
         # 2. Look up the mapping row by ebook_filename (matches current or original).
@@ -1771,11 +1777,12 @@ class SyncManager:
 
         # 3. Map source to the appropriate client and download by ID.
         client = None
-        if ebook_source == "BookOrbit":
+        normalized_source = normalize_ebook_source(ebook_source)
+        if normalized_source == "BookOrbit":
             client = self.active_bookorbit_client
-        elif ebook_source == "BookLore":
+        elif normalized_source == "Booklore":
             client = self.active_booklore_client
-        elif ebook_source == "Kavita":
+        elif normalized_source == "Kavita":
             client = self.active_kavita_client
         else:
             return None
@@ -1825,10 +1832,33 @@ class SyncManager:
         logger.info(f"✅ Downloaded EPUB to cache: '{cached_path}'")
         return cached_path
 
-    def _resolve_local_epub_uncached(self, ebook_filename):
+    def _resolve_local_epub_uncached(self, ebook_filename, _seen=None):
         """
         Get local path to EPUB file, downloading from Grimmory if necessary.
         """
+        # A reconciled library mapping may expose a new remote filename while the
+        # existing bytes intentionally remain cached under the original name.
+        # A second mapping can itself own that original filename, so retain a
+        # visited set rather than assuming the lookup returns the same row.
+        seen = set() if _seen is None else _seen
+        filename_key = str(ebook_filename)
+        if filename_key in seen:
+            logger.warning(
+                "Detected cyclic local EPUB filename mapping at '%s'; falling back",
+                sanitize_log_data(filename_key),
+            )
+            return None
+        seen.add(filename_key)
+        try:
+            mapped_book = self.database_service.get_book_by_ebook_filename(ebook_filename)
+        except Exception:
+            mapped_book = None
+        stable_local_filename = local_ebook_filename(mapped_book) if mapped_book else None
+        if stable_local_filename and stable_local_filename != ebook_filename:
+            stable_path = self._resolve_local_epub_uncached(stable_local_filename, seen)
+            if stable_path is not None:
+                return stable_path
+
         # 1. Try the parser's resolve_book_path first. It has a path-resolution
         #    cache (instant repeat lookups), managed-cache bypass for BookFusion/
         #    Storyteller files, and the same filesystem + cache-dir search.
@@ -3074,8 +3104,19 @@ class SyncManager:
                         book.original_ebook_filename = book.ebook_filename
                         logger.info(f"   ⚡ Preserving original filename: '{book.original_ebook_filename}'")
 
-                # Update the active filename to the one we just used/downloaded
-                book.ebook_filename = new_filename
+                # A source-side rename changes remote metadata, not the local cache
+                # identity. Do not oscillate ebook_filename back to the original
+                # cache basename after reconciliation.
+                stable_local = local_ebook_filename(book)
+                mapped_remote_identity = bool(
+                    getattr(book, "ebook_source", None)
+                    and getattr(book, "ebook_source_id", None)
+                    and stable_local
+                    and new_filename == stable_local
+                    and not is_storyteller_filename(new_filename)
+                )
+                if not mapped_remote_identity:
+                    book.ebook_filename = new_filename
             
             # Guard against a delete that landed after transcription finished but
             # before we persist (e.g. via SMIL/Storyteller paths that don't hit the
@@ -5233,7 +5274,7 @@ class SyncManager:
     def _resolve_grimmory_ebook_id(self, book):
         """Resolve the Grimmory book ID for a book's ebook. Returns int or None."""
         # Fast path: book explicitly sourced from Grimmory
-        if getattr(book, 'ebook_source', None) == "BookLore" and getattr(book, 'ebook_source_id', None):
+        if is_grimmory_source(getattr(book, 'ebook_source', None)) and getattr(book, 'ebook_source_id', None):
             try:
                 return int(book.ebook_source_id)
             except (TypeError, ValueError):

--- a/src/utils/ebook_sources.py
+++ b/src/utils/ebook_sources.py
@@ -1,0 +1,63 @@
+"""Canonical ebook-source names and identity helpers."""
+
+from typing import Optional
+
+
+_SOURCE_NAMES = {
+    "booklore": "Booklore",
+    "grimmory": "Booklore",
+    "bookorbit": "BookOrbit",
+    "kavita": "Kavita",
+    "bookfusion": "BookFusion",
+    "abs": "ABS",
+    "cwa": "CWA",
+    "local file": "Local File",
+}
+
+
+def normalize_ebook_source(value) -> str:
+    """Return the project-wide canonical spelling for an ebook source."""
+    source = str(value or "").strip()
+    if not source:
+        return ""
+    return _SOURCE_NAMES.get(source.lower(), source)
+
+
+def source_name_variants(value) -> tuple[str, ...]:
+    """Return lowercased stored spellings for one canonical ebook source."""
+    canonical = normalize_ebook_source(value)
+    if not canonical:
+        return ()
+    variants = {
+        alias
+        for alias, canonical_name in _SOURCE_NAMES.items()
+        if canonical_name == canonical
+    }
+    variants.add(canonical.lower())
+    return tuple(sorted(variants))
+
+
+def is_grimmory_source(value) -> bool:
+    """Whether *value* is a BookLore/Grimmory source-name variant."""
+    return normalize_ebook_source(value) == "Booklore"
+
+
+def is_storyteller_filename(value) -> bool:
+    return str(value or "").lower().startswith("storyteller_")
+
+
+def local_ebook_filename(book) -> Optional[str]:
+    """Return the stable local/cache filename for a mapped ebook.
+
+    ``ebook_filename`` may follow mutable source metadata.  The original name is
+    retained as the local cache/device identity.  Storyteller artifacts remain the
+    active local file because they are generated content rather than source
+    metadata.
+    """
+    current = getattr(book, "ebook_filename", None)
+    current = current if isinstance(current, str) and current else None
+    if is_storyteller_filename(current):
+        return current
+    original = getattr(book, "original_ebook_filename", None)
+    original = original if isinstance(original, str) and original else None
+    return original or current

--- a/src/web_server.py
+++ b/src/web_server.py
@@ -40,6 +40,7 @@ from src.utils.user_config import SERVICE_ENABLE_KEYS
 from src.utils.config_loader import ConfigLoader, KNOWN_SETTING_KEYS, env_truthy
 from src.utils.cache_paths import safe_cache_path, safe_library_path, is_plain_basename
 from src.utils.ebook_utils import LRUCache
+from src.utils.ebook_sources import is_grimmory_source, local_ebook_filename, normalize_ebook_source
 from src.utils.logging_utils import memory_log_handler, LOG_PATH
 from src.utils.logging_utils import sanitize_log_data
 from src.utils.logging_utils import get_persistent_condition_logger
@@ -1901,9 +1902,12 @@ def get_kosync_id_for_ebook(ebook_filename, booklore_id=None, original_filename=
 
     # Check the EPUB cache explicitly when LibraryService acquired a file outside /books.
     epub_cache = container.epub_cache_dir()
-    cached_path = safe_cache_path(epub_cache, ebook_filename)
-    if cached_path and cached_path.exists():
-         return container.ebook_parser().get_kosync_id(cached_path)
+    for cache_filename in dict.fromkeys((ebook_filename, original_filename)):
+        if not cache_filename:
+            continue
+        cached_path = safe_cache_path(epub_cache, cache_filename)
+        if cached_path and cached_path.exists():
+            return container.ebook_parser().get_kosync_id(cached_path)
 
     # On-demand fetching
     # 0. BookOrbit On-Demand — the library hosts the file via API even when the
@@ -2328,6 +2332,7 @@ def _preserve_or_reset_mapping_status(
     ebook_filename=None,
     audio_source_id=None,
     storyteller_uuid=None,
+    ebook_source=None,
     ebook_source_id=None,
 ) -> None:
     """Queue a mapping for processing, unless its existing alignment still applies.
@@ -2354,9 +2359,22 @@ def _preserve_or_reset_mapping_status(
     # readalong uuid and the ebook source id are as much a part of the pairing as
     # the filename — swapping a book to a different Storyteller readalong changes
     # the audio the map was built against.
+    existing_source = _normalize_text_source_type(getattr(target_book, "ebook_source", None))
+    next_source = _normalize_text_source_type(ebook_source) if ebook_source is not None else existing_source
+    existing_source_id = str(getattr(target_book, "ebook_source_id", None) or "").strip()
+    next_source_id = str(ebook_source_id or "").strip()
+    same_stable_ebook = bool(
+        existing_source
+        and next_source
+        and existing_source.lower() == next_source.lower()
+        and existing_source_id
+        and next_source_id
+        and existing_source_id == next_source_id
+    )
+
     candidates = (
         ("kosync_doc_id", kosync_doc_id),
-        ("ebook_filename", ebook_filename),
+        ("ebook_filename", None if same_stable_ebook else ebook_filename),
         ("audio_source_id", audio_source_id),
         ("storyteller_uuid", storyteller_uuid),
         ("ebook_source_id", ebook_source_id),
@@ -2373,6 +2391,17 @@ def _preserve_or_reset_mapping_status(
         # would re-transcribe books this guard exists to spare.
         if existing and str(existing) != str(new_value):
             changed.append(attr)
+
+    if ebook_source is not None and existing_source and existing_source.lower() != next_source.lower():
+        changed.append("ebook_source")
+
+    if same_stable_ebook and not changed:
+        logger.info(
+            "♻️ '%s' External ebook metadata changed with stable source identity — "
+            "preserving mapping status",
+            sanitize_log_data(abs_id),
+        )
+        return
 
     reusable = False
     if not changed and abs_id:
@@ -2632,6 +2661,7 @@ def _upsert_storyteller_mapping(
         kosync_doc_id=kosync_doc_id,
         ebook_filename=resolved_ebook_filename,
         storyteller_uuid=selected_storyteller_uuid,
+        ebook_source=selected_ebook_source,
         ebook_source_id=selected_ebook_source_id,
     )
     target_book.abs_title = abs_title or target_book.abs_title or Path(resolved_ebook_filename).stem
@@ -3360,20 +3390,7 @@ def _build_bridge_key(audio_source, audio_source_id):
 
 
 def _normalize_text_source_type(raw_source):
-    source_text = str(raw_source or "").strip()
-    if not source_text:
-        return ""
-    source_map = {
-        "booklore": "Booklore",
-        "grimmory": "Booklore",
-        "bookorbit": "BookOrbit",
-        "kavita": "Kavita",
-        "bookfusion": "BookFusion",
-        "abs": "ABS",
-        "cwa": "CWA",
-        "local file": "Local File",
-    }
-    return source_map.get(source_text.lower(), source_text)
+    return normalize_ebook_source(raw_source)
 
 
 def _safe_local_source_path(raw_path) -> str:
@@ -3489,7 +3506,7 @@ def _create_or_update_library_audio_mapping(
         return None, "Please select a text source (Storyteller or Standard Ebook)", 400
 
     booklore_ebook_id = None
-    if ebook_source == "BookLore":
+    if is_grimmory_source(ebook_source):
         booklore_ebook_id = ebook_source_id
     elif uc().booklore_client.is_configured():
         bl_book = uc().booklore_client.find_book_by_filename(original_ebook_filename or resolved_ebook_filename)
@@ -3536,6 +3553,7 @@ def _create_or_update_library_audio_mapping(
         ebook_filename=resolved_ebook_filename,
         audio_source_id=str(audio_source_id),
         storyteller_uuid=storyteller_uuid,
+        ebook_source=ebook_source,
         ebook_source_id=ebook_source_id,
     )
     target_book.audio_source = audio_source
@@ -5004,7 +5022,7 @@ def _browser_cover_url(
     ebook_src = (ebook_source or "").strip()
     ebook_id = (ebook_source_id or "").strip()
     if ebook_id:
-        if ebook_src == "BookLore":
+        if is_grimmory_source(ebook_src):
             return f"/api/booklore/audiobook-cover/{ebook_id}"
         if ebook_src == "BookOrbit":
             return f"/api/bookorbit/audiobook-cover/{ebook_id}"
@@ -6561,6 +6579,7 @@ def match():
                 ebook_filename=ebook_filename,
                 audio_source_id=abs_id,
                 storyteller_uuid=effective_storyteller_uuid,
+                ebook_source=ebook_source,
                 ebook_source_id=ebook_source_id,
             )
             resolved_status = current_book_entry.status or "pending"
@@ -8649,6 +8668,9 @@ def cleanup_mapping_resources(book, defer_audio_cache: bool = False):
             remaining_filename = getattr(remaining_book, 'ebook_filename', None)
             if remaining_filename:
                 remaining_cache_filenames.add(remaining_filename)
+            remaining_local_filename = local_ebook_filename(remaining_book)
+            if remaining_local_filename:
+                remaining_cache_filenames.add(remaining_local_filename)
 
             remaining_uuid = getattr(remaining_book, 'storyteller_uuid', None)
             if not remaining_uuid and remaining_filename:
@@ -8683,11 +8705,12 @@ def cleanup_mapping_resources(book, defer_audio_cache: bool = False):
         except Exception as e:
             logger.warning(f"⚠️ Failed to delete transcript directory: {e}", exc_info=True)
 
+    cached_ebook_filename = local_ebook_filename(book)
     preserve_cached_ebook = (
         remaining_books is None
-        or book.ebook_filename in remaining_cache_filenames
+        or cached_ebook_filename in remaining_cache_filenames
     )
-    if book.ebook_filename and not preserve_cached_ebook:
+    if cached_ebook_filename and not preserve_cached_ebook:
         cache_dirs = []
         try:
             cache_dirs.append(container.epub_cache_dir())
@@ -8706,13 +8729,13 @@ def cleanup_mapping_resources(book, defer_audio_cache: bool = False):
                 continue
             seen_dirs.add(cache_dir_key)
 
-            cached_path = safe_cache_path(cache_dir_path, book.ebook_filename)
+            cached_path = safe_cache_path(cache_dir_path, cached_ebook_filename)
             if cached_path and cached_path.exists():
                 try:
                     cached_path.unlink()
-                    logger.info(f"🗑️ Deleted cached ebook file: {book.ebook_filename}")
+                    logger.info(f"🗑️ Deleted cached ebook file: {cached_ebook_filename}")
                 except Exception as e:
-                    logger.warning(f"⚠️ Failed to delete cached ebook {book.ebook_filename}: {e}", exc_info=True)
+                    logger.warning(f"⚠️ Failed to delete cached ebook {cached_ebook_filename}: {e}", exc_info=True)
 
     # KoSync progress must not outlive the mapping. The document hash comes from
     # the EPUB's content, so re-matching the same file re-links the identical hash
@@ -11144,6 +11167,10 @@ def api_booklore_refresh():
 
     if not refreshed:
         return jsonify({"success": False, "error": "Grimmory refresh failed"}), 500
+
+    reconcile = getattr(client, "reconcile_mapping_filename_drift", None)
+    if callable(reconcile):
+        reconcile()
 
     return jsonify({"success": True, "message": "Grimmory cache refreshed successfully"})
 

--- a/tests/test_booklore_client.py
+++ b/tests/test_booklore_client.py
@@ -712,6 +712,7 @@ def test_refresh_book_cache_hydrates_small_library(booklore_client):
             filename=f"small-book-{book_id.split('-')[-1]}.epub",
         )
     )
+    booklore_client.reconcile_mapping_filename_drift = MagicMock()
 
     assert booklore_client._refresh_book_cache(refresh_stale_details=False) is True
     assert booklore_client._fetch_book_detail.call_count == 3
@@ -719,6 +720,7 @@ def test_refresh_book_cache_hydrates_small_library(booklore_client):
     assert len(booklore_client._book_id_cache) == 3
     assert all(not info.get('_needs_detail') for info in booklore_client._book_id_cache.values())
     assert booklore_client.db.save_booklore_book.call_count == 3
+    booklore_client.reconcile_mapping_filename_drift.assert_not_called()
 
 
 def test_refresh_book_cache_skips_bulk_detail_fetch_for_large_library(booklore_client):

--- a/tests/test_bookorbit_api_only_acquisition.py
+++ b/tests/test_bookorbit_api_only_acquisition.py
@@ -160,6 +160,41 @@ class TestBookOrbitApiOnlyAcquisition(unittest.TestCase):
         bookorbit_client.find_book_by_filename.assert_not_called()
         bookorbit_client.download_book.assert_not_called()
 
+    def test_grimmory_source_spelling_variants_all_download_by_id(self):
+        for index, source in enumerate(("grimmory", "Booklore", "BookLore")):
+            with self.subTest(source=source):
+                manager = self._setup_manager_for_resolution(_build_manager(self.tmp_path))
+                ebook_filename = f"variant-{index}.epub"
+                manager.database_service.get_book_by_ebook_filename.return_value = (
+                    _make_book_row(ebook_filename, source, "4")
+                )
+                manager.booklore_client.is_configured.return_value = True
+                manager.booklore_client.download_book.return_value = b"Grimmory bytes"
+                manager.booklore_client.find_book_by_filename = MagicMock(return_value=None)
+
+                result = manager._resolve_local_epub_uncached(ebook_filename)
+
+                self.assertEqual(result, manager.epub_cache_dir / ebook_filename)
+                manager.booklore_client.download_book.assert_called_once_with("4")
+                manager.booklore_client.find_book_by_filename.assert_not_called()
+
+    def test_reconciled_remote_name_reuses_original_cached_file(self):
+        manager = self._setup_manager_for_resolution(_build_manager(self.tmp_path))
+        old_filename = "old-name.epub"
+        new_filename = "new-name.epub"
+        book_row = _make_book_row(new_filename, "Booklore", "4")
+        book_row.original_ebook_filename = old_filename
+        manager.database_service.get_book_by_ebook_filename.return_value = book_row
+        manager.epub_cache_dir.mkdir(parents=True, exist_ok=True)
+        old_path = manager.epub_cache_dir / old_filename
+        old_path.write_bytes(b"existing cached bytes")
+
+        result = manager._resolve_local_epub_uncached(new_filename)
+
+        self.assertEqual(result, old_path)
+        self.assertFalse((manager.epub_cache_dir / new_filename).exists())
+        manager.booklore_client.download_book.assert_not_called()
+
     def test_legacy_mapping_falls_back_to_filename_search(self):
         """
         C — Legacy mapping falls back.

--- a/tests/test_bookorbit_match_hash.py
+++ b/tests/test_bookorbit_match_hash.py
@@ -94,6 +94,28 @@ def test_kosync_id_skips_bookorbit_when_local_file_present():
     bookorbit.download_book.assert_not_called()
 
 
+def test_kosync_id_checks_both_remote_and_original_cache_names():
+    bookorbit = MagicMock()
+    bookorbit.is_configured.return_value = False
+
+    with tempfile.TemporaryDirectory() as tmp:
+        old_name = "old-name.epub"
+        new_name = "new-name.epub"
+        old_path = Path(tmp) / old_name
+        old_path.write_bytes(b"cached")
+        container, parser = _container(tmp, "unused")
+        parser.get_kosync_id.return_value = "stablehash"
+        with patch.object(web_server, "uc", return_value=_clients(bookorbit)), \
+             patch.object(web_server, "container", container), \
+             patch.object(web_server, "find_ebook_file", return_value=None):
+            result = web_server.get_kosync_id_for_ebook(
+                new_name, original_filename=old_name
+            )
+
+    assert result == "stablehash"
+    parser.get_kosync_id.assert_called_once_with(old_path)
+
+
 def test_kosync_id_prefers_selected_source_path_before_filename_glob():
     """Approved Suggestions should hash the selected ebook file, not the first basename match."""
     bookorbit = MagicMock()

--- a/tests/test_grimmory_mapping_rename_resilience.py
+++ b/tests/test_grimmory_mapping_rename_resilience.py
@@ -1,0 +1,532 @@
+import threading
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import src.web_server as web_server
+import src.api.kosync_server as kosync_server
+from src.api.booklore_client import BookloreClient
+from src.db.database_service import DatabaseService
+from src.db.models import Book
+from src.services.library_service import LibraryService
+from src.sync_clients.booklore_sync_client import BookloreSyncClient
+from src.sync_clients.sync_client_interface import LocatorResult, UpdateProgressRequest
+
+
+OLD_CBZ = "Suske en Wiske - 002 - De Vliegende Aap.cbz"
+NEW_CBZ = "De vliegende aap - Willy Vandersteen (1996).cbz"
+
+
+def mapped_book(filename="old-name.epub", source="BookLore", source_id="4"):
+    return Book(
+        abs_id="book-1",
+        abs_title="Book",
+        ebook_filename=filename,
+        original_ebook_filename=filename,
+        ebook_source=source,
+        ebook_source_id=source_id,
+        kosync_doc_id="stable-kosync-hash",
+        status="active",
+    )
+
+
+@pytest.mark.parametrize("source", ["BookLore", "Booklore", "Grimmory"])
+def test_mapped_read_uses_stable_id_after_filename_alias_is_removed(source):
+    api = MagicMock(spec=BookloreClient)
+    api.get_progress_rich_by_book_id.return_value = {
+        "pct": 1.0,
+        "cfi": None,
+        "href": None,
+        "last_read_time": None,
+        "status": "READ",
+    }
+    sync = BookloreSyncClient(api, MagicMock())
+
+    state = sync.get_service_state(mapped_book(OLD_CBZ, source), prev_state=None)
+
+    assert state.current["pct"] == 1.0
+    api.get_progress_rich_by_book_id.assert_called_once_with("4")
+    api.find_book_by_filename.assert_not_called()
+    api.find_book_by_filename_exact.assert_not_called()
+
+
+@pytest.mark.parametrize("filename", ["old-name.epub", OLD_CBZ])
+def test_mapped_write_uses_stable_id_for_epub_and_cbz(filename):
+    api = MagicMock(spec=BookloreClient)
+    api.update_progress_by_book_id.return_value = True
+    sync = BookloreSyncClient(api, MagicMock())
+    request = UpdateProgressRequest(locator_result=LocatorResult(percentage=1.0))
+
+    result = sync.update_progress(mapped_book(filename), request)
+
+    assert result.success is True
+    api.update_progress_by_book_id.assert_called_once_with("4", 1.0, request.locator_result)
+    api.update_progress.assert_not_called()
+    api.find_book_by_filename.assert_not_called()
+
+
+def test_legacy_exact_filename_fallback_backfills_source_id_without_fuzzy_match():
+    api = MagicMock(spec=BookloreClient)
+    api.db = MagicMock()
+    api.find_book_by_filename_exact.return_value = {"id": 4, "fileName": "legacy.epub"}
+    api.get_progress_rich_by_book_id.return_value = {"pct": 0.25, "cfi": None}
+    book = mapped_book("legacy.epub", source="Grimmory", source_id=None)
+    sync = BookloreSyncClient(api, MagicMock())
+
+    state = sync.get_service_state(book, prev_state=None)
+
+    assert state.current["pct"] == 0.25
+    assert book.ebook_source_id == "4"
+    api.find_book_by_filename_exact.assert_called_once_with("legacy.epub")
+    api.find_book_by_filename.assert_not_called()
+    api.db.backfill_ebook_source_id_if_unclaimed.assert_called_once_with(
+        "book-1", "4", "Booklore"
+    )
+
+
+def test_legacy_resolver_rejects_non_grimmory_source_before_lookup():
+    api = MagicMock(spec=BookloreClient)
+    sync = BookloreSyncClient(api, MagicMock())
+    book = mapped_book("same-name.epub", source="BookOrbit", source_id=None)
+
+    assert sync._resolve_legacy_book_id(book, "same-name.epub") is None
+
+    api.find_book_by_filename_exact.assert_not_called()
+
+
+def bare_client(db, books_by_id):
+    client = BookloreClient.__new__(BookloreClient)
+    client.db = db
+    client._cache_lock = threading.RLock()
+    client._book_cache = {
+        str(info.get("fileName")).lower(): info
+        for info in books_by_id.values()
+        if isinstance(info, dict) and info.get("fileName")
+    }
+    client._book_id_cache = books_by_id
+    client._exact_filename_miss_cache = {}
+    client._refresh_cooldown = 300
+    client._cache_timestamp = time.time()
+    client._creds = {}
+    return client
+
+
+def response(status_code=200):
+    value = MagicMock()
+    value.status_code = status_code
+    value.__bool__.return_value = True
+    return value
+
+
+def test_api_rich_read_by_id_is_one_direct_get():
+    client = bare_client(None, {})
+    client._make_request = MagicMock(return_value=response())
+    client._parse_json_response = MagicMock(return_value={
+        "id": 4,
+        "primaryFile": {"fileName": "new-name.epub", "bookType": "EPUB"},
+        "epubProgress": {"percentage": 34.48, "cfi": "epubcfi(/6/4!)"},
+    })
+
+    rich = client.get_progress_rich_by_book_id("4")
+
+    assert rich["pct"] == pytest.approx(0.3448)
+    client._make_request.assert_called_once_with("GET", "/api/v1/books/4")
+    assert client._get_cached_book_by_id("4")["fileName"] == "new-name.epub"
+
+
+def test_api_write_by_id_keeps_payload_and_verification_without_filename_lookup():
+    detail = {
+        "id": 4,
+        "fileName": "new-name.epub",
+        "primaryFile": {"id": 44, "fileName": "new-name.epub", "bookType": "EPUB"},
+        "epubProgress": {"percentage": 10.3448},
+    }
+    client = bare_client(None, {4: detail})
+    client._epub_cfi_write_disabled_for_books = set()
+    client.find_book_by_filename = MagicMock()
+    client._make_request = MagicMock(side_effect=[response(204), response(200)])
+    client._parse_json_response = MagicMock(return_value={
+        **detail,
+        "epubProgress": {"percentage": 100.0},
+    })
+
+    assert client.update_progress_by_book_id(4, 1.0, LocatorResult(percentage=1.0)) is True
+
+    first_call = client._make_request.call_args_list[0]
+    assert first_call.args[:2] == ("POST", "/api/v1/books/progress")
+    assert first_call.args[2] == {
+        "bookId": 4,
+        "fileProgress": {"bookFileId": 44, "progressPercent": 100.0},
+    }
+    assert client._make_request.call_args_list[1].args == ("GET", "/api/v1/books/4")
+    client.find_book_by_filename.assert_not_called()
+
+
+def test_rich_read_then_write_reuses_hydrated_detail():
+    detail = {
+        "id": 4,
+        "primaryFile": {"id": 44, "fileName": "new-name.epub", "bookType": "EPUB"},
+        "epubProgress": {"percentage": 10.0},
+    }
+    verified = {**detail, "epubProgress": {"percentage": 100.0}}
+    client = bare_client(None, {})
+    client._epub_cfi_write_disabled_for_books = set()
+    client._make_request = MagicMock(
+        side_effect=[response(200), response(204), response(200)]
+    )
+    client._parse_json_response = MagicMock(side_effect=[detail, verified])
+
+    assert client.get_progress_rich_by_book_id("4")["pct"] == pytest.approx(0.1)
+    assert client.update_progress_by_book_id(
+        "4", 1.0, LocatorResult(percentage=1.0)
+    ) is True
+
+    assert [call.args[:2] for call in client._make_request.call_args_list] == [
+        ("GET", "/api/v1/books/4"),
+        ("POST", "/api/v1/books/progress"),
+        ("GET", "/api/v1/books/4"),
+    ]
+
+
+def test_cold_detail_lookup_accepts_string_mapping_id_and_integer_api_id():
+    client = bare_client(None, {})
+    client._get_fresh_token = MagicMock(return_value="token")
+    client._fetch_book_detail = MagicMock(return_value={"id": 4})
+
+    def cache_integer_id(_detail):
+        client._book_id_cache[4] = {"id": 4, "fileName": "new-name.epub"}
+
+    client._process_book_detail = cache_integer_id
+
+    assert client._fetch_and_cache_detail("4") == {
+        "id": 4,
+        "fileName": "new-name.epub",
+    }
+
+
+def test_failed_direct_rich_read_does_not_issue_duplicate_classic_get():
+    api = MagicMock(spec=BookloreClient)
+    api.get_progress_rich_by_book_id.return_value = None
+    sync = BookloreSyncClient(api, MagicMock())
+
+    assert sync.get_service_state(mapped_book(), prev_state=None) is None
+
+    api.get_progress_rich_by_book_id.assert_called_once_with("4")
+    api.get_progress_by_book_id.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("old_filename", "new_filename"),
+    [("old-name.epub", "new-name.epub"), (OLD_CBZ, NEW_CBZ)],
+)
+def test_library_reconcile_refreshes_only_external_filename(old_filename, new_filename):
+    book = mapped_book(old_filename)
+    db = MagicMock()
+    db.get_all_books.return_value = [book]
+    db.update_book_fields.return_value = True
+    client = bare_client(db, {4: {"id": 4, "fileName": new_filename}})
+
+    assert client.reconcile_mapping_filename_drift() == 1
+
+    db.update_book_fields.assert_called_once_with(
+        "book-1",
+        expected_ebook_source_id="4",
+        expected_grimmory_source=True,
+        notify_catalog_change=True,
+        ebook_filename=new_filename,
+    )
+    assert book.ebook_filename == old_filename
+    assert book.original_ebook_filename == old_filename
+    assert book.ebook_source_id == "4"
+    assert book.kosync_doc_id == "stable-kosync-hash"
+    assert book.status == "active"
+
+
+def test_library_reconcile_does_not_relink_missing_known_id_by_filename():
+    book = mapped_book("same-name.epub", source_id="404")
+    db = MagicMock()
+    db.get_all_books.return_value = [book]
+    client = bare_client(db, {5: {"id": 5, "fileName": "same-name.epub"}})
+
+    assert client.reconcile_mapping_filename_drift() == 0
+
+    assert book.ebook_source_id == "404"
+    assert book.ebook_filename == "same-name.epub"
+    db.update_book_fields.assert_not_called()
+
+
+def test_library_reconcile_backfills_only_unambiguous_exact_legacy_match():
+    exact = mapped_book("exact.epub", source="booklore", source_id=None)
+    ambiguous = mapped_book("duplicate.epub", source="Grimmory", source_id=None)
+    ambiguous.abs_id = "book-2"
+    db = MagicMock()
+    db.get_all_books.return_value = [exact, ambiguous]
+    db.backfill_ebook_source_id_if_unclaimed.return_value = True
+    client = bare_client(db, {
+        4: {"id": 4, "fileName": "exact.epub"},
+        5: {"id": 5, "fileName": "duplicate.epub"},
+        6: {"id": 6, "fileName": "duplicate.epub"},
+    })
+
+    assert client.reconcile_mapping_filename_drift() == 1
+
+    assert exact.ebook_source_id == "4"
+    assert ambiguous.ebook_source_id is None
+    db.backfill_ebook_source_id_if_unclaimed.assert_called_once_with(
+        "book-1", "4", "Booklore"
+    )
+
+
+def test_library_reconcile_rejects_two_legacy_mappings_claiming_one_source_id():
+    first = mapped_book("duplicate.epub", source="booklore", source_id=None)
+    second = mapped_book("duplicate.epub", source="Grimmory", source_id=None)
+    second.abs_id = "book-2"
+    db = MagicMock()
+    db.get_all_books.return_value = [first, second]
+    client = bare_client(db, {4: {"id": 4, "fileName": "duplicate.epub"}})
+
+    assert client.reconcile_mapping_filename_drift() == 0
+
+    db.backfill_ebook_source_id_if_unclaimed.assert_not_called()
+    assert first.ebook_source_id is None
+    assert second.ebook_source_id is None
+
+
+def test_library_reconcile_does_not_backfill_with_incomplete_filename_catalog():
+    legacy = mapped_book("exact.epub", source="Grimmory", source_id=None)
+    db = MagicMock()
+    db.get_all_books.return_value = [legacy]
+    client = bare_client(db, {
+        4: {"id": 4, "fileName": "exact.epub"},
+        5: {"id": 5, "fileName": None, "_needs_detail": True},
+    })
+
+    assert client.reconcile_mapping_filename_drift() == 0
+
+    db.backfill_ebook_source_id_if_unclaimed.assert_not_called()
+
+
+def test_reconcile_narrow_write_preserves_concurrent_sync_fields(tmp_path):
+    db = DatabaseService(str(tmp_path / "reconcile.db"))
+    try:
+        db.save_book(mapped_book("old-name.epub"))
+        stale_snapshot = db.get_book("book-1")
+
+        current = db.get_book("book-1")
+        current.status = "processing"
+        current.kosync_doc_id = "concurrent-kosync-hash"
+        current.transcript_file = "concurrent.json"
+        db.save_book(current)
+
+        db.get_all_books = MagicMock(return_value=[stale_snapshot])
+        client = bare_client(db, {4: {"id": 4, "fileName": "new-name.epub"}})
+
+        assert client.reconcile_mapping_filename_drift() == 1
+
+        saved = db.get_book("book-1")
+        assert saved.ebook_filename == "new-name.epub"
+        assert saved.status == "processing"
+        assert saved.kosync_doc_id == "concurrent-kosync-hash"
+        assert saved.transcript_file == "concurrent.json"
+    finally:
+        db.db_manager.close()
+
+
+def test_reconcile_conditional_write_does_not_touch_concurrently_remapped_book(tmp_path):
+    db = DatabaseService(str(tmp_path / "conditional-reconcile.db"))
+    try:
+        db.save_book(mapped_book("old-name.epub"))
+        stale_snapshot = db.get_book("book-1")
+
+        current = db.get_book("book-1")
+        current.ebook_source_id = "99"
+        current.ebook_filename = "other-book.epub"
+        db.save_book(current)
+
+        db.get_all_books = MagicMock(return_value=[stale_snapshot])
+        client = bare_client(db, {4: {"id": 4, "fileName": "new-name.epub"}})
+
+        assert client.reconcile_mapping_filename_drift() == 0
+
+        saved = db.get_book("book-1")
+        assert saved.ebook_source_id == "99"
+        assert saved.ebook_filename == "other-book.epub"
+    finally:
+        db.db_manager.close()
+
+
+def test_database_backfill_allows_only_one_mapping_to_claim_source_id(tmp_path):
+    db = DatabaseService(str(tmp_path / "source-claim.db"))
+    try:
+        first = mapped_book("duplicate.epub", source="Grimmory", source_id=None)
+        second = mapped_book("duplicate.epub", source="booklore", source_id=None)
+        second.abs_id = "book-2"
+        db.save_book(first)
+        db.save_book(second)
+
+        assert db.backfill_ebook_source_id_if_unclaimed("book-1", "4", "Booklore")
+        assert not db.backfill_ebook_source_id_if_unclaimed("book-2", "4", "Booklore")
+
+        assert db.get_book("book-1").ebook_source_id == "4"
+        assert db.get_book("book-2").ebook_source_id is None
+    finally:
+        db.db_manager.close()
+
+
+@pytest.mark.parametrize("stored_source", ["BookLore", "Booklore", "Grimmory", "grimmory"])
+def test_database_source_lookup_normalizes_grimmory_aliases(tmp_path, stored_source):
+    db = DatabaseService(str(tmp_path / "source-lookup.db"))
+    try:
+        db.save_book(mapped_book(source=stored_source, source_id="4"))
+
+        found = db.get_book_by_ebook_source("BookLore", "4")
+
+        assert found is not None
+        assert found.abs_id == "book-1"
+    finally:
+        db.db_manager.close()
+
+
+def test_exact_filename_lookup_uses_hourly_refresh_and_negative_cache():
+    client = bare_client(None, {4: {"id": 4, "fileName": "present.epub"}})
+    client._is_refresh_on_cooldown = MagicMock(return_value=False)
+    client._refresh_book_cache = MagicMock(return_value=True)
+    client._cache_timestamp = time.time() - 120
+
+    assert client.find_book_by_filename_exact("missing.epub") is None
+    assert client.find_book_by_filename_exact("missing.epub") is None
+    client._refresh_book_cache.assert_not_called()
+
+    client._exact_filename_miss_cache.clear()
+    client._cache_timestamp = time.time() - 3601
+    assert client.find_book_by_filename_exact("missing.epub") is None
+    assert client.find_book_by_filename_exact("missing.epub") is None
+    client._refresh_book_cache.assert_called_once_with()
+
+
+def test_exact_filename_lookup_rejects_duplicate_catalog_ids():
+    first = {"id": 4, "fileName": "duplicate.epub"}
+    second = {"id": 5, "fileName": "duplicate.epub"}
+    client = bare_client(None, {4: first, 5: second})
+
+    assert client.find_book_by_filename_exact("duplicate.epub", allow_refresh=False) is None
+
+
+def test_local_cached_filename_survives_external_rename(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    old_cache = cache_dir / "old-name.epub"
+    old_cache.write_bytes(b"cached" * 300)
+    book = mapped_book("new-name.epub")
+    book.original_ebook_filename = "old-name.epub"
+    api = MagicMock()
+    api.is_configured.return_value = True
+    service = LibraryService(MagicMock(), api, MagicMock(), MagicMock(), str(cache_dir))
+
+    result = service.acquire_ebook({}, book)
+
+    assert result == str(old_cache)
+    api.download_book.assert_not_called()
+    assert book.kosync_doc_id == "stable-kosync-hash"
+
+
+def test_scheduled_library_sync_runs_mapping_reconciliation():
+    api = MagicMock()
+    api.is_configured.return_value = True
+    api.get_all_books.return_value = []
+    service = LibraryService(MagicMock(), api, MagicMock(), MagicMock(), "/tmp/cache")
+    service.get_syncable_books = MagicMock(return_value=[])
+
+    service.sync_library_books()
+
+    api.get_all_books.assert_called_once_with()
+    api.reconcile_mapping_filename_drift.assert_called_once_with()
+
+
+def test_same_source_and_id_filename_change_keeps_active(monkeypatch):
+    db = MagicMock()
+    db.has_alignment.return_value = True
+    monkeypatch.setattr(web_server, "database_service", db)
+    book = mapped_book("old-name.epub", source="Grimmory", source_id="4")
+
+    web_server._preserve_or_reset_mapping_status(
+        book,
+        ebook_filename="new-name.epub",
+        ebook_source="BookLore",
+        ebook_source_id="4",
+    )
+
+    assert book.status == "active"
+
+
+def test_same_source_and_id_ebook_only_mapping_keeps_active_without_alignment(monkeypatch):
+    db = MagicMock()
+    db.has_alignment.return_value = False
+    monkeypatch.setattr(web_server, "database_service", db)
+    book = mapped_book("old-name.epub", source="grimmory", source_id="4")
+    book.sync_mode = "ebook_only"
+
+    web_server._preserve_or_reset_mapping_status(
+        book,
+        ebook_filename="new-name.epub",
+        ebook_source="Booklore",
+        ebook_source_id="4",
+    )
+
+    assert book.status == "active"
+    db.has_alignment.assert_not_called()
+
+
+@pytest.mark.parametrize("source", ["grimmory", "Booklore", "BookLore"])
+def test_kosync_auto_map_keeps_grimmory_id_for_all_source_spellings(monkeypatch, source):
+    mapping_service = MagicMock()
+    saved = SimpleNamespace(
+        abs_id="book-1",
+        ebook_source=source,
+        ebook_source_id="4",
+    )
+    mapping_service.create_audio_mapping_from_match.return_value = saved
+    container = MagicMock()
+    container.book_mapping_service.return_value = mapping_service
+    database = MagicMock()
+    monkeypatch.setattr(kosync_server, "_container", container)
+    monkeypatch.setattr(kosync_server, "_database_service", database)
+    monkeypatch.setattr(kosync_server, "_manager", None)
+    monkeypatch.setattr(
+        kosync_server,
+        "_resolve_library_ebook_source",
+        lambda _filename: (source, "4"),
+    )
+
+    result = kosync_server._auto_map_ebook_to_audiobook(
+        "hash", "renamed.epub", {"abs_id": "audio-1", "title": "Book"}, "test"
+    )
+
+    assert result is saved
+    assert mapping_service.create_audio_mapping_from_match.call_args.kwargs[
+        "booklore_ebook_id"
+    ] == "4"
+
+
+@pytest.mark.parametrize(
+    ("new_source", "new_id"),
+    [("Grimmory", "5"), ("BookOrbit", "4")],
+)
+def test_changed_source_identity_still_requeues(monkeypatch, new_source, new_id):
+    db = MagicMock()
+    db.has_alignment.return_value = True
+    monkeypatch.setattr(web_server, "database_service", db)
+    book = mapped_book("old-name.epub", source="BookLore", source_id="4")
+
+    web_server._preserve_or_reset_mapping_status(
+        book,
+        ebook_filename="new-name.epub",
+        ebook_source=new_source,
+        ebook_source_id=new_id,
+    )
+
+    assert book.status == "pending"
+    db.has_alignment.assert_not_called()

--- a/tests/test_mapping_status_reuse.py
+++ b/tests/test_mapping_status_reuse.py
@@ -24,12 +24,15 @@ class _Book:
     """Minimal stand-in with the identity attributes the guard inspects."""
 
     def __init__(self, abs_id="ab-1", status="active", kosync_doc_id=None,
-                 ebook_filename=None, audio_source_id=None):
+                 ebook_filename=None, audio_source_id=None, ebook_source=None,
+                 ebook_source_id=None):
         self.abs_id = abs_id
         self.status = status
         self.kosync_doc_id = kosync_doc_id
         self.ebook_filename = ebook_filename
         self.audio_source_id = audio_source_id
+        self.ebook_source = ebook_source
+        self.ebook_source_id = ebook_source_id
 
 
 class MappingStatusReuseTestCase(unittest.TestCase):

--- a/tests/test_sync_manager_parser_routing.py
+++ b/tests/test_sync_manager_parser_routing.py
@@ -155,3 +155,27 @@ def test_resolve_local_epub_uncached_parser_preferred_over_filesystem(tmp_path):
     # Parser path wins
     assert result == parser_path
     assert result.read_bytes() == b"parser version"
+
+
+def test_resolve_local_epub_uncached_stops_cyclic_original_filename_mappings(tmp_path):
+    parser = MagicMock()
+    parser.resolve_book_path.return_value = None
+    first = Book(
+        abs_id="first",
+        ebook_filename="remote-a.epub",
+        original_ebook_filename="cache-b.epub",
+    )
+    second = Book(
+        abs_id="second",
+        ebook_filename="cache-b.epub",
+        original_ebook_filename="remote-a.epub",
+    )
+    manager = _build_manager(tmp_path, ebook_parser=parser)
+    manager.database_service.get_book_by_ebook_filename.side_effect = (
+        lambda filename: {"remote-a.epub": first, "cache-b.epub": second}.get(filename)
+    )
+    manager.booklore_client.is_configured.return_value = False
+
+    assert manager._resolve_local_epub_uncached("remote-a.epub") is None
+
+    assert parser.resolve_book_path.call_count == 2


### PR DESCRIPTION
## Summary

Make existing Grimmory/BookLore ebook mappings use the stable external `ebook_source_id` as identity, so renaming the remote file no longer disconnects progress sync.

## Problem

A mapped Grimmory book can keep the same book id while its primary filename changes after metadata editing. BookBridge already stores that stable id, but progress read/write paths could still re-resolve by filename. Once the old filename alias disappeared, live sync could stop even though the mapped resource itself had not changed.

## Fix

- use `ebook_source_id` first for mapped Grimmory progress reads;
- use the same stable id for progress writes;
- reconcile remote filename drift for the same source id without treating it as a new mapping;
- preserve `original_ebook_filename`, KoSync identity, progress state, alignment and active status across a same-id rename;
- retain exact filename fallback for legacy mappings without a source id;
- backfill a missing source id only from a unique exact match;
- avoid fuzzy/LLM relinking and avoid relinking a known missing id to another book with the same filename;
- normalize BookLore/Booklore/Grimmory source variants consistently.

## Remap semantics

Same source + same source id + new filename is metadata drift only and remains active.

A different source id or different source remains a real remap and keeps existing pending/reprocessing behavior.

## Validation

The branch includes regressions for direct by-id reads/writes, same-id filename reconciliation, EPUB and CBZ renames, exact legacy-id backfill, missing known ids, source normalization, preservation of local filename/KoSync identity and true-remap behavior.

The original rename scenario continues syncing correctly after the old filename alias is removed.

## Scope

This PR is limited to stable external identity and filename-drift resilience for Grimmory mappings. CBZ fixed-page progress, cover routing, KoSync multi-device sibling policy and deployment workflows are separate changes.